### PR TITLE
fix for $ and % in DATA statements

### DIFF
--- a/basic/code21.s
+++ b/basic/code21.s
@@ -44,6 +44,14 @@ clrfac	sta facho
 	sta faclo
 	tay 
 intrts	rts
+.ifndef C64
+finh	bcc fin	; skip test for 0-9
+	cmp #'$'
+	beq finh2
+	cmp #'%'
+	bne fin
+finh2	jmp frmevl
+.endif
 fin	ldy #$00
 	ldx #$09+addprc
 finzlp	sty deccnt,x

--- a/basic/code8.s
+++ b/basic/code8.s
@@ -25,7 +25,12 @@ nowge1	jsr strlt2
 	jsr st2txt
 	jsr inpcom
 	jmp strdn2
-numins	jsr frmevl
+numins
+.ifdef C64
+	jsr fin
+.else
+	jsr finh
+.endif
 	lda intflg
 	jsr qintgr
 strdn2	jsr chrgot


### PR DESCRIPTION
The reason for the bug was that the FIN function uses a literal value for the negative sign, $2D, see here:
https://www.pagetable.com/c64disasm/#BCFE
but the EVAL function, which is called by the FRMEVL function, uses the minus token, $AB, see here:
https://www.pagetable.com/c64disasm/#AEB1
But the values in a DATA statement are not tokenized, so it reads the literal minus, $2D, and since it doesn't recognize it, it results in a syntax error.

This fix adds the $ and % functionality with as few side effects for the existing functionality as possible, so every existing C64 program should now work. Test case (might be good to have some automatic regression testing) :
```
10 READ A, B, C, D, E$, F$, G$, H, I
20 READ J,K,L,M,N,O,P,Q
30 READ R,S,T,U,V,W,X
40 PRINT A;B;C;D;E$;F$;G$;H;I
50 PRINT J;K;L;M;N;O;P;Q
60 PRINT R;S;T;U;V;W;X
70 DATA 10,11, 12,13 ,"HELLO ","WORLD","!",$E, $F
80 DATA $10,$11,18,%10011,20,$15, $16,-23
90 DATA .1,1E5,-.1,.1E5,-.1E-5,1.1E5,-1.1E-2
```
The only remaining problem is that you can't use negative hex numbers inside DATA statements. But I have no idea how to fix it without major rewrites of the BASIC ROM. But probably nobody needs this anyway, and then we wait for a bug report, if someone really needs it :-)