### PR TITLE
Allow LOAD with address and add VLOAD

### DIFF
--- a/basic/code26.s
+++ b/basic/code26.s
@@ -172,8 +172,7 @@ plsv
 	jsr plsv7       ;get ',fa'
 	ldy #0          ;command 0
 	stx andmsk
-	jsr $ffba
-	jsr paoc20      ;by-pass junk
+	jsr paoc19      ;store then by-pass junk
 	jsr plsv7       ;get ',sa'
 	txa             ;new command
 	tay
@@ -183,6 +182,9 @@ plsv
 ;look for comma followed by byte
 plsv7	jsr paoc30
 	jmp getbyt
+
+;store file parms then maybe end
+paoc19	jsr $ffba
 
 ;skip return if next char is end
 ;
@@ -210,8 +212,7 @@ paoc	lda #0
 	txa
 	ldx #1          ;default device
 	ldy #0          ;default command
-	jsr $ffba       ;store it
-	jsr paoc20      ;skip junk
+	jsr paoc19      ;store then by-pass junk
 	jsr plsv7
 	stx eormsk
 	ldy #0          ;default command
@@ -219,15 +220,13 @@ paoc	lda #0
 	cpx #3
 	bcc paoc5
 	dey             ;default ieee to $ff
-paoc5	jsr $ffba       ;store them
-	jsr paoc20      ;skip junk
+paoc5	jsr paoc19      ;store then by-pass junk
 	jsr plsv7       ;get sa
 	txa
 	tay
 	ldx eormsk
 	lda andmsk
-	jsr $ffba       ;set up real eveything
-paoc7	jsr paoc20
+	jsr paoc19      ;store then by-pass junk
 	jsr paoc30
 paoc15	jsr frmevl
 	jsr frestr      ;length in .a

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -82,23 +82,25 @@ cverf	lda #1          ;verify flag
 	.byt $2c        ;skip two bytes
 
 cload	lda #0          ;load flag
-	sta verck
+	pha
 	jsr plsv        ;parse parameters
 	bcs cld10
 	ldx andmsk
 	stx $9f61
+	pla
 ;
 cld10	; jsr $ffe1 ;check run/stop
 ; cmp #$ff ;done yet?
 ; bne cld10 ;still bouncing
-	lda verck
+	sta verck
 	ldx poker       ;.x and .y have alt...
 	ldy poker+1     ;...load address
 	jsr $ffd5       ;load it
 	bcs jerxit      ;problems
 ;
 	lda verck
-	beq cld50       ;was load
+	cmp #1
+	bne cld50       ;was load
 ;
 ;finish verify
 ;

--- a/basic/declare.s
+++ b/basic/declare.s
@@ -21,7 +21,7 @@ integr
 charac	.res 1
 endchr	.res 1
 trmpos	.res 1
-verck	.res 1
+	.res 1           ;unused (was verck)
 count	.res 1
 dimflg	.res 1
 valtyp	.res 1

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -60,9 +60,10 @@ gotk	=$cb
 reslst2	.byt "MO", 'N' + $80
 	.byt "DO", 'S' + $80
 	.byt "VPOK", 'E' + $80
+	.byt "VLOA", 'D' + $80
 	.byt "VPEE", 'K' + $80
 	.byt 0
-num_esc_statements = 3
+num_esc_statements = 4
 num_esc_functions = 1
 .endif
 

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -113,10 +113,8 @@ err26	.byt "CAN",$27,"T CONTINU",$c5
 errcn	=26
 err27	.byt "UNDEF",$27,"D FUNCTIO",$ce
 erruf	=27
-err28	.byt "VERIF",$d9
-ervfy	=28
-err29	.byt "LOA",$c4
-erload	=29
+err28	.byt "LOA",$c4
+erload	=28
 
 ; table to translate error message #
 ; to address of string containing message
@@ -150,15 +148,13 @@ errtab	.word err01
 	.word err27
 	.word err28
 	.word err29
-	.word err30
 
-okmsg	.byt $d,"OK",$d,$0
 err	.byt $20," ERROR",0 ;add a space for vic-40 screen
 intxt	.byt " IN ",0
 reddy	.byt $d,$a,"READY.",$d,$a,0
-erbrk	=30
+erbrk	=29
 brktxt	.byt $d,$a
-err30	.byt "BREAK",0,$a0 ;shifted space
+err29	.byt "BREAK",0,$a0 ;shifted space
 
 forsiz	=$12
 fndfor	tsx

--- a/basic/tokens.s
+++ b/basic/tokens.s
@@ -87,6 +87,7 @@ stmdsp2	; statements
 	.word monitor-1
 	.word dos-1
 	.word vpoke-1
+	.word vload-1
 	; functions
 	.word vpeek
 .endif

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -99,7 +99,7 @@ vload	jsr plsv   ;parse the parameters
 	bcc vld1   ;require bank/addr
 	jmp snerr
 vld1	lda andmsk ;bank number
-	adc #2
+	adc #1
 	jmp cld10  ;jump to load command
 
 ;***************

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -95,6 +95,14 @@ vpoke	jsr getbyt ; bank
 	rts
 
 ;***************
+vload	jsr plsv   ;parse the parameters
+	bcc vld1   ;require bank/addr
+	jmp snerr
+vld1	lda andmsk ;bank number
+	adc #2
+	jmp cld10  ;jump to load command
+
+;***************
 dos	beq ptstat      ;no argument: print status
 	jsr frmevl
 	jsr frestr      ;length in .a

--- a/kernal/declare.s
+++ b/kernal/declare.s
@@ -8,7 +8,7 @@ status	.res 1           ;i/o operation status byte
 ; crfac .res 2 ;correction factor (unused)
 stkey	.res 1           ;stop key flag
 savbank	.res 1           ;old bank when switching (was: tape)
-verck	.res 1           ;load or verify flag
+verck	.res 1           ;load or vload flag
 c3p0	.res 1           ;ieee buffered char flag
 bsour	.res 1           ;char buffer for ieee
 	.res 1           ;unused (tape)

--- a/kernal/load.s
+++ b/kernal/load.s
@@ -1,7 +1,7 @@
 ;**********************************
 ;* load ram function              *
 ;*                                *
-;* loads or verifies from serial  *
+;* loads from serial              *
 ;* bus devices >=4 to 31 as       *
 ;* determined by contents of      *
 ;* variable fa.                   *
@@ -9,9 +9,8 @@
 ;* alt load if sa=0, normal sa=1  *
 ;* .x , .y load address if sa=0   *
 ;* .a=0 performs load to ram      *
-;* .a=1 performs verify           *
-;* .a>1 performs load to vram;    *
-;*      (.a-2)&0x0f is the bank   *
+;* .a>0 performs load to vram;    *
+;*      (.a-1)&0x0f is the bank   *
 ;*      number.                   *
 ;*                                *
 ;* high load return in x,y,a      *
@@ -23,8 +22,7 @@ loadsp	stx memuss      ;.x has low alt start
 load	jmp (iload)     ;monitor load entry
 ;
 nload	and #$1f
-	sta verck       ;store verify flag
-	dec verck
+	sta verck       ;store vram flag/bank
 	lda #0
 	sta status
 ;
@@ -76,7 +74,6 @@ ld30	jsr loding      ;tell user loading
 ;
 	ldy verck       ;are we loading into vram?
 	beq ld40        ;no
-	bmi ld40        ;no
 ;
 ;initialize vera registers
 ;
@@ -107,17 +104,10 @@ ld45	jsr acptr       ;get byte off ieee
 	bcs ld40        ;yes...try again
 	txa
 	ldy verck       ;what operation are we doing?
-	bmi ld50        ;load into ram
-	beq ld47        ;verify
+	beq ld50        ;load into ram
 ;
 	sta veradat     ;write into vram
 	bne ld60        ;branch always
-;
-ld47	cmp (eal),y     ;verify it
-	beq ld60        ;o.k....
-	lda #16         ;no good...verify error (sperr)
-	jsr udst        ;update status
-	.byt $2c        ;skip next store
 ;
 ld50	sta (eal),y
 ld60	inc eal         ;increment store addr
@@ -134,7 +124,6 @@ ld64	bit status      ;eoi?
 ;
 	lda verck
 	clc
-	bmi ld80
 	beq ld80
 	ldx veralo
 	ldy veramid
@@ -174,17 +163,12 @@ ld115	rts
 
 ;subroutine to print:
 ;
-;loading/verifing
+;loading
 ;
-loding	ldy #ms10-ms1   ;assume 'loading'
-	lda verck       ;check flag
-	bne ld410       ;are doing load
-	ldy #ms21-ms1   ;are 'verifying'
-ld410	jsr spmsg
+loding	ldy #ms10-ms1   ;'loading'
+	jsr spmsg
 	bit msgflg      ;printing messages?
 	bpl frmto1      ;no...
-	lda verck       ;check flag
-	beq frmto1      ;skip if verify
 	ldy #ms7-ms1    ;"from $"
 msghex	jsr msg
 	lda eah
@@ -206,7 +190,5 @@ hex010	adc #$30
 frmto1	rts
 prnto	bit msgflg      ;printing messages?
 	bpl frmto1      ;no...
-	lda verck       ;check flag
-	beq frmto1      ;skip if verify
 	ldy #ms8-ms1    ;"to $"
 	bne msghex      ;branch always

--- a/kernal/messages.s
+++ b/kernal/messages.s
@@ -6,9 +6,7 @@ ms7	.byte " FROM ",'$'+$80
 ms8	.byte " TO ",'$'+$80
 ms10	.byt $d,"LOADIN",$c7
 ms11	.byt $d,"SAVING",$a0
-ms21	.byt $d,"VERIFYIN",$c7
 ms17	.byt $d,"FOUND",$a0
-ms18	.byt $d,"OK",$8d
 ; ms34 .byt $d,"MONITOR",$8d
 ; ms36 .byt $d,"BREA",$cb
 


### PR DESCRIPTION
_There are some issues with this PR that will probably require discussion._

This PR does a few things:
- add a `VLOAD` command to load files directly into video RAM
- extend the `LOAD` command to allow specifying a RAM bank and address
- disable the `VERIFY` command (to make room in BASIC ROM for the other changes)

The new functionality is currently incompatible with the emulator because the emulator intercepts calls to the KERNAL load subroutine for device 1.  I was able to test by temporarily modifying a few of the KERNAL IO subroutines to stream dummy data on device 8.

The `LOAD` command can now be used in either of two forms:
- `LOAD [filename[,device[,relocate]]]` (the original form)
- `LOAD [filename[,device[,bank,address]]]`

In the second form, the RAM bank is switched, then the file is loaded at the specified address.

The `VLOAD` command only supports the second form:
- `VLOAD [filename[,device[,bank,address]]]`

This loads a file into video RAM beginning at the specified bank and address.

There are [differences of opinion on Facebook](https://www.facebook.com/groups/CommanderX16/permalink/524303641654068/) as to whether it's okay to eliminate the `VERIFY` command.  I made sure it was removed in the final commit so it's easy to restore if desired.  I'm willing to modify this PR to expand BASIC ROM into multiple banks, but I thought it would be worth posting as-is first.