### PR TITLE
Fix address mistakes in rom.cfg

### DIFF
--- a/rom.cfg
+++ b/rom.cfg
@@ -32,11 +32,11 @@ MEMORY {
 
 	# Bank 1 (KEYMAPS)
 	KEYMAPS:  start = $C000, size = $3FFE, fill=yes, fillval=$AA;
-	IRQA:     start = $3FFE, size = $0002, fill=yes, fillval=$AA;
+	IRQA:     start = $FFFE, size = $0002, fill=yes, fillval=$AA;
 
 	# Bank 2 (CBDOS)
 	CBDOS:    start = $C000, size = $3FFE, fill=yes, fillval=$AA;
-	IRQB:     start = $3FFE, size = $0002, fill=yes, fillval=$AA;
+	IRQB:     start = $FFFE, size = $0002, fill=yes, fillval=$AA;
 
 	# Bank 3 (GEOS)
 	LOKERNAL:     start = $C000, size = $0100, fill=yes, fillval=$AA;


### PR DESCRIPTION
First off, I'm still not entirely familiar with how the ROM project functionally works yet, and I might be completely wrong about this. However, from what I've figured out so far, this appears to be the right change to make. Let me know if I'm wrong about this.

I noticed what (I think) is a typo in rom.cfg. When setting the addresses for `IRQA` and `IRQB` (for `CBDOS` and `GEOS`), they were put in the wrong page. I think what happened was that they used the value from the previous memory's `size` parameter, instead of the previous memory's `start + size` value. These two appear to be the only ones that have this issue.