### PR TITLE
Fix a bug in LOAD/VERIFY

### DIFF
--- a/basic/code26.s
+++ b/basic/code26.s
@@ -82,10 +82,10 @@ cverf	lda #1          ;verify flag
 cload	lda #0          ;load flag
 	pha
 	jsr plsv        ;parse parameters
-	bcs cld10
+	bcs cld9
 	ldx andmsk
 	stx $9f61
-	pla
+cld9	pla
 ;
 cld10	; jsr $ffe1 ;check run/stop
 ; cmp #$ff ;done yet?


### PR DESCRIPTION
This fixes https://github.com/commanderx16/x16-emulator/issues/162
This fixes https://github.com/commanderx16/x16-rom/issues/47

Due to an incorrect branch, the accumulator wasn't being restored after the call to parse the LOAD parameters.  As a result, the KERNAL was loading the data into video memory instead of normal RAM.