### PR TITLE
Make load routine wrap into next RAM bank

### DIFF
--- a/kernal/load.s
+++ b/kernal/load.s
@@ -123,6 +123,19 @@ ld50	sta (eal),y
 ld60	inc eal         ;increment store addr
 	bne ld64
 	inc eah
+;
+;if necessary, wrap to next bank
+;
+	lda eah
+	cmp #$c0        ;reached top of high ram?
+	bne ld64        ;no
+	lda verck       ;check mode
+	beq ld62        ;verify
+	bpl ld64        ;loading into vram
+ld62	lda #$a0        ;wrap to bottom of high ram
+	sta eah
+	inc $9f61       ;move to next ram bank
+
 ld64	bit status      ;eoi?
 	bvc ld40        ;no...continue load
 ;


### PR DESCRIPTION
This changes the LOAD command to wrap into the next RAM bank whenever it reaches the end of the high RAM area.  This makes it easy to load files larger than 8K into high memory.

Corresponding Emulator change: https://github.com/commanderx16/x16-emulator/pull/165

Credit for the idea goes to [Artur Bujdoso](https://www.facebook.com/groups/CommanderX16/permalink/517307852353647/?comment_id=517330952351337) and/or [Tom Wilson](https://www.facebook.com/groups/CommanderX16/permalink/524303641654068/?comment_id=524556388295460).
