### PR TITLE
Add Travis CI integration for Linux and macOS to check PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: bionic
+sudo: required
+language: c
+
+matrix:
+  include:
+    - name: Linux
+      os: linux
+      addons:
+        apt:
+          packages:
+            - cc65
+      compiler: gcc
+      script: make clean all
+    - name: macOS
+      os: osx
+      osx_image: xcode11
+      addons:
+        homebrew:
+          packages:
+            - cc65
+      script: make clean all

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This is the Commander X16 ROM containing BASIC, KERNAL, DOS and GEOS. BASIC and 
 Releases and Building
 ---------------------
 
+<a href="https://travis-ci.org/commanderx16/x16-emulator"><img alt="Travis (.org)" src="https://img.shields.io/travis/commanderx16/x16-rom.svg?label=CI&logo=travis&logoColor=white&style=for-the-badge"></a>
+
 Each [release of the X16 emulator][emu-releases] includes a compatible build of `rom.bin`. If you wish to build this yourself (perhaps because you're also building the emulator) see below.
 
 > __WARNING:__ The emulator will currently work only with a contemporary version of `rom.bin`; earlier or later versions are likely to fail.


### PR DESCRIPTION
Similar to my [commit](https://github.com/commanderx16/x16-emulator/commit/f34190deb98ef27f9baf85e64751a36a607fbd65) on the emulator repository, this will build PRs on Travis CI to verify patches do not break the build. As before the owner of the repository needs to enable the repository on Travis CI to get the builds running. [Here](https://travis-ci.org/tobier/x16-rom/builds/595503666) is a build on my fork that runs and passes.