### PR TITLE
load bugfixes and skip IO area native implementation

### DIFF
--- a/kernal/load.s
+++ b/kernal/load.s
@@ -128,15 +128,24 @@ ld60	inc eal         ;increment store addr
 ;
 ;if necessary, wrap to next bank
 ;
+	lda verck       ;check mode
+	bpl ld64        ;loading into vram
 	lda eah
 	cmp #$c0        ;reached top of high ram?
-	bne ld64        ;no
-	lda verck       ;check mode
-	beq ld62        ;verify
-	bpl ld64        ;loading into vram
-ld62	lda #$a0        ;wrap to bottom of high ram
+	bne ld61        ;no
+	lda #$a0        ;wrap to bottom of high ram
 	sta eah
 	inc $9f61       ;move to next ram bank
+;
+;skip IO area
+;
+ld61	lda eah
+	cmp #$9f        ;reached top of low ram?
+	bne ld64        ;no
+	lda #$a0        ;skip to start of high ram
+	sta eah
+	lda #0
+	sta $9f61
 
 ld64	bit status      ;eoi?
 	bvc ld40        ;no...continue load

--- a/kernal/load.s
+++ b/kernal/load.s
@@ -113,13 +113,15 @@ ld45	jsr acptr       ;get byte off ieee
 	sta veradat     ;write into vram
 	bne ld60        ;branch always
 ;
-ld47	cmp (eal),y     ;verify it
+ld47	ldy #0
+	cmp (eal),y     ;verify it
 	beq ld60        ;o.k....
 	lda #16         ;no good...verify error (sperr)
 	jsr udst        ;update status
 	.byt $2c        ;skip next store
 ;
-ld50	sta (eal),y
+ld50	ldy #0
+	sta (eal),y
 ld60	inc eal         ;increment store addr
 	bne ld64
 	inc eah


### PR DESCRIPTION
See the individual commits for details. The native load bug with the wrong Y register was the reason why after loading with the SD card there was no program, see here:

https://murray2.com/threads/creating-disk-image-for-the-emulator.459/#post-2803

For testing the ROM load functionality, I added this code in emulator_loop, and remove the LOAD_HYPERCALLS block:
```
// F247 acptr
if ((pc == 0xF247) && is_kernal() && RAM[FA] == 8) {
	static FILE* f = NULL;
	if (!f) {
		char filename[41];
		uint8_t len = RAM[FNLEN];
		memcpy(filename, (char *)&RAM[RAM[FNADR] | RAM[FNADR + 1] << 8], len);
		filename[len] = 0;
		printf("open file %s\n", filename);
		f = fopen(filename, "rb");
		if (!f) {
			printf("file open error\n");
		}
	}
	if (f) {
		int c = fread(&a, 1, 1, f);
		if (c) {
			// no error
			RAM[STATUS] = 0;
		} else {
			// EOI
			RAM[STATUS] = 0x40;
		}
	} else {
		// hack: set EOI on file not found, loads still some bytes, but at least doesn't hang
		RAM[STATUS] = 0x40;
	}
	pc = (RAM[0x100 + sp + 1] | (RAM[0x100 + sp + 2] << 8)) + 1;
	sp += 2;
}
```
This allowed me to load a file with `LOAD"FILE.PRG",8`, which then used the native LOAD function and my C hyper function for the acptr function. You can test the new IO skip functionality with the test file mentioned in the other PR: http://www.frank-buss.de/x16/mode7-full.prg

The best would be to implement the IEC protocol, or to fix the SD-card function, which is still not working, but different errors. See the 8 bit guy forum article for a SD card test file.