### PR TITLE
got rid of $2c partial instruction skip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ endif
 AS           = ca65
 LD           = ld65
 
-ARGS_KERNAL=-g
-ARGS_BASIC=-g
-#ARGS_MONITOR=-g
+ARGS_KERNAL=-g --cpu 65SC02 
+ARGS_BASIC=-g --cpu 65SC02 
+ARGS_MONITOR=-g --cpu 65SC02 
 #ARGS_DOS=-g
 #ARGS_GEOS=-g
 

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -138,9 +138,9 @@ fingo	lda fundsp-onefun-onefun+256,y
 	jsr jmper
 	jmp chknum
 orop	ldy #255
-	bra js30
+	bra :+
 andop	ldy #0
-js30:	sty count
+:	sty count
 	jsr ayint
 	lda facmo
 	eor count

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -138,9 +138,9 @@ fingo	lda fundsp-onefun-onefun+256,y
 	jsr jmper
 	jmp chknum
 orop	ldy #255
-	.byt $2c
+	bra js30
 andop	ldy #0
-	sty count
+js30:	sty count
 	jsr ayint
 	lda facmo
 	eor count

--- a/basic/code12.s
+++ b/basic/code12.s
@@ -76,7 +76,7 @@ nmary1	iny
 	adc lowtr+1
 	bcc lopfda
 bserr	ldx #errbs
-	.byt $2c
+	bra errgo3
 fcerr	ldx #errfc
 errgo3	jmp error
 gotary	ldx #errdd

--- a/basic/code13.s
+++ b/basic/code13.s
@@ -127,9 +127,9 @@ errdir	ldx curlin+1
 	inx
 	bne dimrts
 	ldx #errid
-	bra js32
+	bra :+
 errguf	ldx #erruf
-js32:	jmp error
+:	jmp error
 def	jsr getfnm
 	jsr errdir
 	jsr chkopn

--- a/basic/code13.s
+++ b/basic/code13.s
@@ -127,9 +127,9 @@ errdir	ldx curlin+1
 	inx
 	bne dimrts
 	ldx #errid
-	.byt $2c
+	bra js32
 errguf	ldx #erruf
-	jmp error
+js32:	jmp error
 def	jsr getfnm
 	jsr errdir
 	jsr chkopn

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -76,10 +76,10 @@ nsnerr6	ldx vartab      ;end save addr
 	rts
 
 cverf	lda #1          ;verify flag
-	bra js35
+	bra :+
 
 cload	lda #0          ;load flag
-js35:	pha
+:	pha
 	jsr plsv        ;parse parameters
 	bcs cld9
 	ldx andmsk

--- a/basic/code26.s
+++ b/basic/code26.s
@@ -76,10 +76,10 @@ nsnerr6	ldx vartab      ;end save addr
 	rts
 
 cverf	lda #1          ;verify flag
-	.byt $2c        ;skip two bytes
+	bra js35
 
 cload	lda #0          ;load flag
-	pha
+js35:	pha
 	jsr plsv        ;parse parameters
 	bcs cld9
 	ldx andmsk

--- a/basic/code5.s
+++ b/basic/code5.s
@@ -11,9 +11,9 @@ return	bne gorts
 	cmp #gosutk
 	beq retu1
 	ldx #errrg
-	.byt $2c
+	bra js21
 userr	ldx #errus
-	jmp error
+js21:	jmp error
 snerr2	jmp snerr
 retu1	pla
 	pla
@@ -33,9 +33,9 @@ addon	tya
 	inc txtptr+1
 remrts	rts
 datan	ldx #':'
-	.byt $2c
+	bra js20
 remn	ldx #0
-	stx charac
+js20:	stx charac
 	ldy #0
 	sty endchr
 exchqt	lda endchr

--- a/basic/code5.s
+++ b/basic/code5.s
@@ -11,9 +11,9 @@ return	bne gorts
 	cmp #gosutk
 	beq retu1
 	ldx #errrg
-	bra js21
+	bra :+
 userr	ldx #errus
-js21:	jmp error
+:	jmp error
 snerr2	jmp snerr
 retu1	pla
 	pla
@@ -33,9 +33,9 @@ addon	tya
 	inc txtptr+1
 remrts	rts
 datan	ldx #':'
-	bra js20
+	bra :+
 remn	ldx #0
-js20:	stx charac
+:	stx charac
 	ldy #0
 	sty endchr
 exchqt	lda endchr

--- a/basic/code7.s
+++ b/basic/code7.s
@@ -18,9 +18,9 @@ outspc
 	lda channl
 	beq crtskp
 	lda #' '
-	.byt $2c
+	bra outdo
 crtskp	lda #29
-	.byt $2c
+	bra outdo
 outqst	lda #'?'
 outdo	jsr outch
 outrts	and #255
@@ -107,7 +107,7 @@ read	ldx datptr
 	ldy datptr+1
 	.byt $a9
 	tya
-	.byt $2c
+	bra inpco1
 inpcon	lda #0
 inpco1	sta inpflg
 	stx inpptr

--- a/basic/code9.s
+++ b/basic/code9.s
@@ -232,9 +232,9 @@ eval4	cmp #fntk
 parchk	jsr chkopn
 	jsr frmevl
 chkcls	lda #41
-	.byt $2c
+	bra synchr
 chkopn	lda #40
-	.byt $2c
+	bra synchr
 chkcom	lda #44
 synchr	ldy #0
 	cmp (txtptr),y

--- a/basic/geos.s
+++ b/basic/geos.s
@@ -161,9 +161,9 @@ get_col:
 	jsr chkcom
 	jsr getbyt
 	txa
-	.byte $2c
+	bra @2
 @1:	lda #0
-	rts
+@2:	rts
 
 set_col:
 	sei

--- a/cbdos/main.asm
+++ b/cbdos/main.asm
@@ -417,11 +417,11 @@ cbdos_acptr:
 
 ; EOF
 	lda #$40
-	.byte $2c
+	bra @js60
 @acptr_nofd:
 ; no fd
 	lda #$02 ; timeout/file not found
-	sta $90
+@js60:	sta $90
 	lda #0
 	ldy save_y
 	ldx save_x
@@ -606,16 +606,16 @@ finished_with_buffer:
 ;****************************************
 set_status_ok:
 	lda #$00
-	.byte $2c
+	bra js61
 set_status_writeprot:
 	lda #$26
-	.byte $2c
+	bra js61
 set_status_synerr:
 	lda #$31
-	.byte $2c
+	bra js61
 set_status_73:
 	lda #$73
-	pha
+js61:	pha
 	pha
 	lsr
 	lsr
@@ -931,16 +931,16 @@ read_dir:
 	sbc #>10
 	bcs gt_10
 	ldx #3
-	.byte $2c
+	bra js62
 gt_10:
 	ldx #2
-	.byte $2c
+	bra js62
 gt_100:
 	ldx #1
-	.byte $2c
+	bra js62
 gt_1000:
 	ldx #0
-	lda #' '
+js62:	lda #' '
 :	jsr storedir
 	dex
 	bne :-

--- a/cbdos/main.asm
+++ b/cbdos/main.asm
@@ -21,9 +21,13 @@
 .importzp filenameptr, krn_ptr1, krn_ptr3, dirptr, read_blkptr, buffer, bank_save
 .include "common.inc"
 IMPORTED_FROM_MAIN=1
+
+.feature labels_without_colons
+
 .include "fat32.inc"
 .include "fcntl.inc"
 .include "65c02.inc"
+
 
 NUM_BUFS = 4
 TOTAL_NUM_BUFS = NUM_BUFS + 3
@@ -417,11 +421,11 @@ cbdos_acptr:
 
 ; EOF
 	lda #$40
-	bra @js60
-@acptr_nofd:
+	bra :+
+@acptr_nofd
 ; no fd
 	lda #$02 ; timeout/file not found
-@js60:	sta $90
+:	sta $90
 	lda #0
 	ldy save_y
 	ldx save_x
@@ -606,16 +610,16 @@ finished_with_buffer:
 ;****************************************
 set_status_ok:
 	lda #$00
-	bra js61
-set_status_writeprot:
+	bra :+
+set_status_writeprot
 	lda #$26
-	bra js61
-set_status_synerr:
+	bra :+
+set_status_synerr
 	lda #$31
-	bra js61
-set_status_73:
+	bra :+
+set_status_73
 	lda #$73
-js61:	pha
+:	pha
 	pha
 	lsr
 	lsr
@@ -931,16 +935,16 @@ read_dir:
 	sbc #>10
 	bcs gt_10
 	ldx #3
-	bra js62
-gt_10:
+	bra :+
+gt_10
 	ldx #2
-	bra js62
-gt_100:
+	bra :+
+gt_100
 	ldx #1
-	bra js62
-gt_1000:
+	bra :+
+gt_1000
 	ldx #0
-js62:	lda #' '
+:	lda #' '
 :	jsr storedir
 	dex
 	bne :-

--- a/fplib/code19.s
+++ b/fplib/code19.s
@@ -105,9 +105,9 @@ mldexp	beq zeremv
 	bcc tryoff
 	bmi goover
 	clc
-	bra js50
+	bra :+
 tryoff	bpl zeremv
-js50	adc #$80
+:	adc #$80
 	sta facexp
 	bne *+5
 	jmp zeroml

--- a/fplib/code19.s
+++ b/fplib/code19.s
@@ -105,9 +105,9 @@ mldexp	beq zeremv
 	bcc tryoff
 	bmi goover
 	clc
-	.byt $2c
+	bra js50
 tryoff	bpl zeremv
-	adc #$80
+js50	adc #$80
 	sta facexp
 	bne *+5
 	jmp zeroml

--- a/fplib/code20.s
+++ b/fplib/code20.s
@@ -29,9 +29,9 @@ movfm	sta index1
 	sty facov
 	rts   
 mov2f	ldx #tempf2
-	.byt $2c
+	bra js51
 mov1f	ldx #tempf1
-	ldy #0
+js51	ldy #0
 	beq movmf
 movmf	jsr round
 	stx index1

--- a/fplib/code20.s
+++ b/fplib/code20.s
@@ -29,9 +29,9 @@ movfm	sta index1
 	sty facov
 	rts   
 mov2f	ldx #tempf2
-	bra js51
+	bra :+
 mov1f	ldx #tempf1
-js51	ldy #0
+:	ldy #0
 	beq movmf
 movmf	jsr round
 	stx index1

--- a/geos/inc/geosmac.inc
+++ b/geos/inc/geosmac.inc
@@ -186,10 +186,13 @@
 
 .ifpc02
 .else
+.ifpsc02
+.else
 .macro bra addr
 	clv
 	bvc addr
 .endmacro
+.endif
 .endif
 
 .macro smb bitN, dest

--- a/geos/kernal/dlgbox/dlgbox1e2.s
+++ b/geos/kernal/dlgbox/dlgbox1e2.s
@@ -99,27 +99,28 @@ DBIcDISK:
 	jsr RstrKernal
 .endif
 	lda #DISK
-	.byte $2c
+	bra js100
 DBIcOK:
 	lda #OK
-	.byte $2c
+	bra js100
 DBIcCANCEL:
 	lda #CANCEL
-	.byte $2c
+	bra js100
 DBIcYES:
 	lda #YES
-	.byte $2c
+	bra js100
 DBIcNO:
 	lda #NO
-	.byte $2c
+	bra js100
 DBIcOPEN:
 	lda #OPEN
-	.byte $2c
+	bra js100
 DBStringFaultVec2:
 	lda #DBSYSOPV
-	.byte $2c
+	bra js100
 DBKeyVector2:
 	lda #DBGETSTRING
+js100
 .else
 DBIcOK:
 	lda #OK

--- a/geos/kernal/dlgbox/dlgbox1e2.s
+++ b/geos/kernal/dlgbox/dlgbox1e2.s
@@ -99,28 +99,28 @@ DBIcDISK:
 	jsr RstrKernal
 .endif
 	lda #DISK
-	bra js100
-DBIcOK:
+	bra :+
+DBIcOK
 	lda #OK
-	bra js100
-DBIcCANCEL:
+	bra :+
+DBIcCANCEL
 	lda #CANCEL
-	bra js100
-DBIcYES:
+	bra :+
+DBIcYES
 	lda #YES
-	bra js100
-DBIcNO:
+	bra :+
+DBIcNO
 	lda #NO
-	bra js100
-DBIcOPEN:
+	bra :+
+DBIcOPEN
 	lda #OPEN
-	bra js100
-DBStringFaultVec2:
+	bra :+
+DBStringFaultVec2
 	lda #DBSYSOPV
-	bra js100
-DBKeyVector2:
+	bra :+
+DBKeyVector2
 	lda #DBGETSTRING
-js100
+:
 .else
 DBIcOK:
 	lda #OK

--- a/geos/kernal/graph/bitmapclip.s
+++ b/geos/kernal/graph/bitmapclip.s
@@ -44,7 +44,7 @@
 _BitOtherClip:
 	ldx #$ff
 .ifdef wheels_size
-	.byte $2c
+	bra BitmClp1
 .else
 	jmp BitmClp1
 .endif

--- a/geos/kernal/graph/graphicsstring.s
+++ b/geos/kernal/graph/graphicsstring.s
@@ -126,7 +126,7 @@ _DoFrame_RecTo:
 _DoPenXYDelta:
 	ldx #1
 .ifdef wheels_size
-	.byte $2c
+	bra DPXD0
 .else
 	bne DPXD0
 .endif

--- a/geos/kernal/graph/pattern.s
+++ b/geos/kernal/graph/pattern.s
@@ -38,7 +38,7 @@ GetColor:
 	eor #1 ; swap black and white
 	bra @c
 @a:	lda #14 ; light blue
-	.byte $2c
+	bra @c
 @b:	lda #6 ; dark blue
 @c:	sta col1
 	lda #$80

--- a/geos/kernal/graph/point.s
+++ b/geos/kernal/graph/point.s
@@ -199,7 +199,7 @@ _DrawPoint:
 	bit compatMode
 	bpl @0b
 	lda #0 ; black
-	.byte $2c
+	bra @0b
 @0:	lda #1 ; white
 @0b:	ldy r5L
 	sty veralo

--- a/geos/kernal/menu/menu1.s
+++ b/geos/kernal/menu/menu1.s
@@ -184,8 +184,7 @@ DoMenu1_1:
 @3:	sec
 @4:	bbrf MOUSEON_BIT, mouseOn, @5
 .ifdef wheels_size_and_speed
-	lda #1 << ICONSON_BIT | 1 << MENUON_BIT
-	.byte $2c ; skip the "LDA #" part of "smbf"
+	smbf ICONSON_BIT, mouseOn
 .else
 	smbf ICONSON_BIT, mouseOn
 .endif

--- a/geos/kernal/process/process3a.s
+++ b/geos/kernal/process/process3a.s
@@ -69,21 +69,21 @@ RProc0:
 .ifdef wheels_size
 _FreezeProcess:
 	lda #$20
-	bra _js200
-_BlockProcess:
+	bra :+
+_BlockProcess
 	lda #$40
-	bra _js200
-_EnableProcess:
+	bra :+
+_EnableProcess
 	lda #$80
-_js200:
+:
 	ora TimersCMDs,x
 	bne LCBBD
 _UnblockProcess:
 	lda #$BF
-	bra _js201
-_UnfreezeProcess:
+	bra :+
+_UnfreezeProcess
 	lda #$DF
-_js201:
+:
 	and TimersCMDs,x
 LCBBD:  sta TimersCMDs,x
 	rts

--- a/geos/kernal/process/process3a.s
+++ b/geos/kernal/process/process3a.s
@@ -69,19 +69,21 @@ RProc0:
 .ifdef wheels_size
 _FreezeProcess:
 	lda #$20
-	.byte $2c
+	bra _js200
 _BlockProcess:
 	lda #$40
-	.byte $2c
+	bra _js200
 _EnableProcess:
 	lda #$80
+_js200:
 	ora TimersCMDs,x
 	bne LCBBD
 _UnblockProcess:
 	lda #$BF
-	.byte $2c
+	bra _js201
 _UnfreezeProcess:
 	lda #$DF
+_js201:
 	and TimersCMDs,x
 LCBBD:  sta TimersCMDs,x
 	rts

--- a/kernal/editor.1.s
+++ b/kernal/editor.1.s
@@ -119,9 +119,9 @@ cint	jsr iokeys
 	cmp #'6'
 	bne nemu
 	lda $9fbd       ;emulator keyboard layout
-	.byte $2c
+	bra js11
 nemu	lda #0          ;US layout
-	jsr setkbd
+js11	jsr setkbd
 	lda #10
 	sta xmax        ;maximum type ahead buffer size
 	sta delay

--- a/kernal/editor.1.s
+++ b/kernal/editor.1.s
@@ -119,9 +119,9 @@ cint	jsr iokeys
 	cmp #'6'
 	bne nemu
 	lda $9fbd       ;emulator keyboard layout
-	bra js11
+	bra :+
 nemu	lda #0          ;US layout
-js11	jsr setkbd
+:	jsr setkbd
 	lda #10
 	sta xmax        ;maximum type ahead buffer size
 	sta delay

--- a/kernal/editor.2.s
+++ b/kernal/editor.2.s
@@ -240,11 +240,11 @@ key5
 	cmp #$9f
 	bne key2
 	lda gdbln
-	.byte $2c
+	bra js2
 key2	lda #$9f
-	.byte $2c
+	bra js2
 key3	eor #$80        ;blink it
-	jsr dspp2       ;display it
+js2:	jsr dspp2       ;display it
 ;
 key4
 	jsr scnkey      ;scan keyboard
@@ -381,13 +381,13 @@ drv_end:
 ; or $80 if shift is down
 is_home:
 	ldx #$13 * 2; home (-> clr)
-	.byte $2c
+	bra js3
 is_enter:
 	ldx #$0d * 2 ; return (-> shift+return)
-	.byte $2c
+	bra js3
 is_stop:
 	ldx #$03 * 2 ; stop (-> run)
-	lda shflag
+js3:	lda shflag
 	lsr ; shift -> C
 	txa
 	ror
@@ -400,9 +400,9 @@ add_to_buf:
 	cmp #3 ; stop
 	bne add1
 	ldx #$7f
-	.byte $2c
+	bra js4
 add1:	ldx #$ff
-	stx stkey
+js4:	stx stkey
 	ldx ndx ; length of keyboard buffer
 	cpx xmax
 	bcs add2 ; full, ignore
@@ -547,10 +547,10 @@ receive_down_scancode_no_modifiers:
 	bcc key_down
 	eor #$ff
 	and shflag
-	.byte $2c
+	bra js5
 key_down:
 	ora shflag
-	sta shflag
+js5: sta shflag
 key_up:	lda #0 ; no key to return
 	rts
 no_mod:	plp
@@ -567,9 +567,9 @@ check_mod:
 	cpx #$e0 ; right alt
 	bne :+
 	lda #MODIFIER_ALT | MODIFIER_CTRL
-	.byte $2c
+	bra :++
 :	lda #MODIFIER_ALT
-	sec
+:	sec
 	rts
 nmd_alt:
 	cmp #$14 ; left ctrl (0014) or right ctrl (E014)
@@ -587,13 +587,13 @@ ckmod2:	cmp #$1F ; left win (001F)
 	cmp #$27 ; right win (0027)
 	bne ckmod1
 md_win:	lda #MODIFIER_WIN
-	.byte $2c
+	bra js1
 md_alt:	lda #MODIFIER_ALT
-	.byte $2c
+	bra js1
 md_ctl:	lda #MODIFIER_CTRL
-	.byte $2c
+	bra js1
 md_sh:	lda #MODIFIER_SHIFT
-	sec
+js1: sec
 	rts
 
 tab_extended:

--- a/kernal/editor.2.s
+++ b/kernal/editor.2.s
@@ -240,11 +240,11 @@ key5
 	cmp #$9f
 	bne key2
 	lda gdbln
-	bra js2
+	bra :+
 key2	lda #$9f
-	bra js2
+	bra :+
 key3	eor #$80        ;blink it
-js2:	jsr dspp2       ;display it
+:	jsr dspp2       ;display it
 ;
 key4
 	jsr scnkey      ;scan keyboard
@@ -381,13 +381,13 @@ drv_end:
 ; or $80 if shift is down
 is_home:
 	ldx #$13 * 2; home (-> clr)
-	bra js3
-is_enter:
+	bra :+
+is_enter
 	ldx #$0d * 2 ; return (-> shift+return)
-	bra js3
-is_stop:
+	bra :+
+is_stop
 	ldx #$03 * 2 ; stop (-> run)
-js3:	lda shflag
+:	lda shflag
 	lsr ; shift -> C
 	txa
 	ror
@@ -400,9 +400,9 @@ add_to_buf:
 	cmp #3 ; stop
 	bne add1
 	ldx #$7f
-	bra js4
-add1:	ldx #$ff
-js4:	stx stkey
+	bra :+
+add1	ldx #$ff
+:	stx stkey
 	ldx ndx ; length of keyboard buffer
 	cpx xmax
 	bcs add2 ; full, ignore
@@ -547,10 +547,10 @@ receive_down_scancode_no_modifiers:
 	bcc key_down
 	eor #$ff
 	and shflag
-	bra js5
-key_down:
+	bra :+
+key_down
 	ora shflag
-js5: sta shflag
+:	sta shflag
 key_up:	lda #0 ; no key to return
 	rts
 no_mod:	plp
@@ -587,13 +587,13 @@ ckmod2:	cmp #$1F ; left win (001F)
 	cmp #$27 ; right win (0027)
 	bne ckmod1
 md_win:	lda #MODIFIER_WIN
-	bra js1
-md_alt:	lda #MODIFIER_ALT
-	bra js1
-md_ctl:	lda #MODIFIER_CTRL
-	bra js1
-md_sh:	lda #MODIFIER_SHIFT
-js1: sec
+	bra :+
+md_alt	lda #MODIFIER_ALT
+	bra :+
+md_ctl	lda #MODIFIER_CTRL
+	bra :+
+md_sh	lda #MODIFIER_SHIFT
+: sec
 	rts
 
 tab_extended:

--- a/kernal/errorhandler.s
+++ b/kernal/errorhandler.s
@@ -27,24 +27,24 @@ stop2	rts
 ;************************************
 ;
 error1	lda #1          ;too many files
-	.byt $2c
+	bra js12
 error2	lda #2          ;file open
-	.byt $2c
+	bra js12
 error3	lda #3          ;file not open
-	.byt $2c
+	bra js12
 error4	lda #4          ;file not found
-	.byt $2c
+	bra js12
 error5	lda #5          ;device not present
-	.byt $2c
+	bra js12
 error6	lda #6          ;not input file
-	.byt $2c
+	bra js12
 error7	lda #7          ;not output file
-	.byt $2c
+	bra js12
 error8	lda #8          ;missing file name
-	.byt $2c
+	bra js12
 error9	lda #9          ;bad device #
 ;
-	pha             ;error number on stack
+js12:	pha             ;error number on stack
 	jsr clrch       ;restore i/o channels
 ;
 	ldy #ms1-ms1

--- a/kernal/errorhandler.s
+++ b/kernal/errorhandler.s
@@ -27,24 +27,24 @@ stop2	rts
 ;************************************
 ;
 error1	lda #1          ;too many files
-	bra js12
+	bra :+
 error2	lda #2          ;file open
-	bra js12
+	bra :+
 error3	lda #3          ;file not open
-	bra js12
+	bra :+
 error4	lda #4          ;file not found
-	bra js12
+	bra :+
 error5	lda #5          ;device not present
-	bra js12
+	bra :+
 error6	lda #6          ;not input file
-	bra js12
+	bra :+
 error7	lda #7          ;not output file
-	bra js12
+	bra :+
 error8	lda #8          ;missing file name
-	bra js12
+	bra :+
 error9	lda #9          ;bad device #
 ;
-js12:	pha             ;error number on stack
+:	pha             ;error number on stack
 	jsr clrch       ;restore i/o channels
 ;
 	ldy #ms1-ms1

--- a/kernal/load.s
+++ b/kernal/load.s
@@ -117,7 +117,7 @@ ld47	cmp (eal),y     ;verify it
 	beq ld60        ;o.k....
 	lda #16         ;no good...verify error (sperr)
 	jsr udst        ;update status
-	.byt $2c        ;skip next store
+	bra ld60
 ;
 ld50	sta (eal),y
 ld60	inc eal         ;increment store addr

--- a/kernal/mouse.s
+++ b/kernal/mouse.s
@@ -75,9 +75,9 @@ mous2:	cmp #$ff
 	tay
 	bcc @5
 	lda #1  ; white
-	.byte $2c
+	bra @6
 @5:	lda #16 ; black
-	sta veradat
+@6:	sta veradat
 	pla
 @4:	dec 0
 	bne @2

--- a/kernal/routines.s
+++ b/kernal/routines.s
@@ -58,10 +58,10 @@ close_all
 	bne @10		;...branch if not current output device
 	lda #3
 	sta dflto	;restore screen output
-	.byte $2c
+	bra js6
 
 @10	cmp dfltn
-	bne @20		;...branch if not current input device
+js6:	bne @20		;...branch if not current input device
 	lda #0
 	sta dfltn	;restore keyboard input
 
@@ -203,9 +203,9 @@ swppp4	lda #$01
 	cpy #25
 	bne swpp1
 	lda #<400
-	.byte $2c
+	bra js7
 swpp1	lda #<480
-	pha
+js7:	pha
 	lda #7 ; vstop_lo
 	sta veralo
 	pla

--- a/kernal/routines.s
+++ b/kernal/routines.s
@@ -58,10 +58,10 @@ close_all
 	bne @10		;...branch if not current output device
 	lda #3
 	sta dflto	;restore screen output
-	bra js6
+	bra :+
 
 @10	cmp dfltn
-js6:	bne @20		;...branch if not current input device
+:	bne @20		;...branch if not current input device
 	lda #0
 	sta dfltn	;restore keyboard input
 
@@ -203,9 +203,9 @@ swppp4	lda #$01
 	cpy #25
 	bne swpp1
 	lda #<400
-	bra js7
+	bra :+
 swpp1	lda #<480
-js7:	pha
+:	pha
 	lda #7 ; vstop_lo
 	sta veralo
 	pla

--- a/kernal/serial4.0.s
+++ b/kernal/serial4.0.s
@@ -12,7 +12,7 @@ talk
 	rts
 .endif
 	ora #$40        ;make a talk adr
-	.byt $2c        ;skip two bytes
+	bra list1       
 
 ;command serial bus device to listen
 ;
@@ -120,7 +120,7 @@ isr04	lda d1icr
 ;
 nodev	;device not present error
 	lda #$80
-	.byt $2c
+	bra csberr
 frmerr	;framing error
 	lda #$03
 csberr	jsr udst        ;commodore serial buss error entry
@@ -208,7 +208,7 @@ untlk
 	ora #$08
 	sta sdata
 	lda #$5f        ;untalk command
-	.byt $2c        ;skip two bytes
+	bra js10
 
 ;send unlisten command on serial bus
 ;
@@ -220,7 +220,7 @@ unlsn
 	rts
 .endif
 	lda #$3f        ;unlisten command
-	jsr list1       ;send it
+js10	jsr list1       ;send it
 ;
 ; release all lines
 dlabye	jsr scatn       ;always release atn

--- a/kernal/serial4.0.s
+++ b/kernal/serial4.0.s
@@ -208,7 +208,7 @@ untlk
 	ora #$08
 	sta sdata
 	lda #$5f        ;untalk command
-	bra js10
+	bra :+
 
 ;send unlisten command on serial bus
 ;
@@ -220,7 +220,7 @@ unlsn
 	rts
 .endif
 	lda #$3f        ;unlisten command
-js10	jsr list1       ;send it
+:	jsr list1       ;send it
 ;
 ; release all lines
 dlabye	jsr scatn       ;always release atn

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -269,9 +269,9 @@ brk_entry2:
         lda     entry_type
         cmp     #'C'
         bne     :+
-        .byte   $2C ; XXX bne + skip = beq + 2
+        bra     :++
 :       lda     #'B'
-        ldx     #'*'
+:       ldx     #'*'
         jsr     print_a_x
         clc
         lda     reg_pc_lo
@@ -355,9 +355,10 @@ LABEB:  ldy     #0
 
 syntax_error:
         lda     #'?'
-        .byte   $2C
+        bra js300
 print_cr_then_input_loop:
         lda     #CR
+js300:
         jsr     BSOUT
 
 input_loop:
@@ -1516,8 +1517,9 @@ cmd_b:  jsr     basin_cmp_cr
         bcs     syn_err3
         and     #$03 ; XXX no effect
         ora     #$40 ; make $40 - $43
-        .byte   $2C
+        bra     js302
 LB326:  lda     #$70 ; by default, hide cartridge
+js302:
         sta     cartridge_bank
         jmp     print_cr_then_input_loop
 .endif
@@ -1560,9 +1562,10 @@ video_loop:
         cmp     #' '
         beq     video_loop
         jsr     hex_digit_to_nybble
-        .byte   $2C
+        bra js303
 default_video_bank:
 	lda     #0
+js303:
 	jmp     store_bank
 
 not_video:
@@ -1572,15 +1575,16 @@ not_video:
 .elseif .defined(MACHINE_X16)
         jsr     get_hex_byte2
 .endif
-        .byte   $2C
+        bra js304
 LB33F:  lda     #DEFAULT_BANK
+js304:
 .ifdef MACHINE_C64
         cmp     #$38
         bcs     syn_err3
         cmp     #$30
         bcc     syn_err3
 .endif
-        .byte   $2C
+        bra store_bank
 LB34A:  lda     #$80 ; drive
 store_bank:
         sta     bank
@@ -1777,11 +1781,12 @@ LB48E:  jsr     print_space
 
 print_up:
         ldx     #CSR_UP
-        .byte   $2C
+        bra     js305
 print_cr_dot:
         ldx     #'.'
+js305:        
         lda     #CR
-        .byte   $2C
+        bra     print_a_x
 print_dot_x:
         lda     #'.'
 print_a_x:
@@ -1792,18 +1797,19 @@ print_a_x:
 print_up_dot:
         jsr     print_up
         lda     #'.'
-        .byte   $2C
+        bra     js306
 ; XXX unused?
         lda     #CSR_RIGHT
-        .byte   $2C
+        bra     js306
 print_hash:
         lda     #'#'
-        .byte   $2C
+        bra     js306
 print_space:
         lda     #' '
-        .byte   $2C
+        bra     js306
 print_cr:
         lda     #CR
+js306:
         jmp     BSOUT
 
 basin_skip_spaces_if_more:
@@ -1914,9 +1920,10 @@ syn_err5:
 
 print_dollar_hex_16:
         lda     #'$'
-        .byte   $2C
+        bra     js307
 print_space_hex_16:
         lda     #' '
+js307:
         jsr     BSOUT
 print_hex_16:
         lda     zp1 + 1
@@ -2119,21 +2126,22 @@ check_end:
 
 fill_kbd_buffer_comma:
         lda     #','
-        .byte   $2C
+        bra     js308
 fill_kbd_buffer_semicolon:
         lda     #':'
-        .byte   $2C
+        bra     js308
 fill_kbd_buffer_a:
         lda     #'A'
-        .byte   $2C
+        bra     js308
 fill_kbd_buffer_leftbracket:
         lda     #'['
-        .byte   $2C
+        bra     js308
 fill_kbd_buffer_rightbracket:
         lda     #']'
-        .byte   $2C
+        bra     js308
 fill_kbd_buffer_singlequote:
         lda     #$27 ; "'"
+js308:
         sta     KEYD
         lda     zp1 + 1
         jsr     byte_to_hex_ascii
@@ -3513,8 +3521,9 @@ LBC58:  lda     #$2F
         sta     zp2 + 1
         sec
         ldy     zp1
-        .byte   $2C
+        bra     js309
 LBC60:  sta     zp1 + 1
+js309:
         sty     zp1
         inc     zp2 + 1
         tya

--- a/monitor/monitor.s
+++ b/monitor/monitor.s
@@ -37,6 +37,8 @@
 ; * "OD" switches all memory dumps/input to the drive's memory.
 ; * "B" command to introspect cartridge ROM
 
+.feature labels_without_colons
+
 .include "kernal.i"
 
 .ifdef CART_FC3
@@ -355,10 +357,10 @@ LABEB:  ldy     #0
 
 syntax_error:
         lda     #'?'
-        bra js300
-print_cr_then_input_loop:
+        bra :+
+print_cr_then_input_loop
         lda     #CR
-js300:
+:
         jsr     BSOUT
 
 input_loop:
@@ -1517,9 +1519,9 @@ cmd_b:  jsr     basin_cmp_cr
         bcs     syn_err3
         and     #$03 ; XXX no effect
         ora     #$40 ; make $40 - $43
-        bra     js302
-LB326:  lda     #$70 ; by default, hide cartridge
-js302:
+        bra     :+
+LB326  lda     #$70 ; by default, hide cartridge
+:
         sta     cartridge_bank
         jmp     print_cr_then_input_loop
 .endif
@@ -1562,10 +1564,10 @@ video_loop:
         cmp     #' '
         beq     video_loop
         jsr     hex_digit_to_nybble
-        bra js303
-default_video_bank:
+        bra		:+
+default_video_bank
 	lda     #0
-js303:
+:
 	jmp     store_bank
 
 not_video:
@@ -1575,9 +1577,9 @@ not_video:
 .elseif .defined(MACHINE_X16)
         jsr     get_hex_byte2
 .endif
-        bra js304
-LB33F:  lda     #DEFAULT_BANK
-js304:
+        bra :+
+LB33F  lda     #DEFAULT_BANK
+:
 .ifdef MACHINE_C64
         cmp     #$38
         bcs     syn_err3
@@ -1781,10 +1783,10 @@ LB48E:  jsr     print_space
 
 print_up:
         ldx     #CSR_UP
-        bra     js305
+        bra     :+
 print_cr_dot:
         ldx     #'.'
-js305:        
+:        
         lda     #CR
         bra     print_a_x
 print_dot_x:
@@ -1797,19 +1799,19 @@ print_a_x:
 print_up_dot:
         jsr     print_up
         lda     #'.'
-        bra     js306
+        bra     :+
 ; XXX unused?
         lda     #CSR_RIGHT
-        bra     js306
-print_hash:
+        bra     :+
+print_hash
         lda     #'#'
-        bra     js306
-print_space:
+        bra     :+
+print_space
         lda     #' '
-        bra     js306
-print_cr:
+        bra     :+
+print_cr
         lda     #CR
-js306:
+:
         jmp     BSOUT
 
 basin_skip_spaces_if_more:
@@ -1920,10 +1922,10 @@ syn_err5:
 
 print_dollar_hex_16:
         lda     #'$'
-        bra     js307
-print_space_hex_16:
+        bra     :+
+print_space_hex_16
         lda     #' '
-js307:
+:
         jsr     BSOUT
 print_hex_16:
         lda     zp1 + 1
@@ -2126,22 +2128,22 @@ check_end:
 
 fill_kbd_buffer_comma:
         lda     #','
-        bra     js308
-fill_kbd_buffer_semicolon:
+        bra     :+
+fill_kbd_buffer_semicolon
         lda     #':'
-        bra     js308
-fill_kbd_buffer_a:
+        bra     :+
+fill_kbd_buffer_a
         lda     #'A'
-        bra     js308
-fill_kbd_buffer_leftbracket:
+        bra     :+
+fill_kbd_buffer_leftbracket
         lda     #'['
-        bra     js308
-fill_kbd_buffer_rightbracket:
+        bra     :+
+fill_kbd_buffer_rightbracket
         lda     #']'
-        bra     js308
-fill_kbd_buffer_singlequote:
+        bra     :+
+fill_kbd_buffer_singlequote
         lda     #$27 ; "'"
-js308:
+:
         sta     KEYD
         lda     zp1 + 1
         jsr     byte_to_hex_ascii
@@ -3521,9 +3523,9 @@ LBC58:  lda     #$2F
         sta     zp2 + 1
         sec
         ldy     zp1
-        bra     js309
-LBC60:  sta     zp1 + 1
-js309:
+        bra     :+
+LBC60  sta     zp1 + 1
+:
         sty     zp1
         inc     zp2 + 1
         tya


### PR DESCRIPTION
To fix various problems I listed under issue #79 I created this pull request.

The .byte $2c hack is a way of skipping a 2 byte instruction with while saving 1 byte over a bra, but it has 4 problems:
1) If the instruction to be skipped over is not 2 bytes long, say a variable moved off zeropage (as just happened) the final byte of the skipped instruction is revealed as a new instruction, which may do different things on different processors or on the emulator (which currently does not implement unused instructions properly).
2) flags are affected.  There is one case where there was a skip to a bne, but the bit instruction overwrites the zero flag.
3) randomish memory is read.  If an instruction aliased to a vera register, for instance, and the read changed the state, that would be a very hard bug to find
4) if the skip is not valid, the assembler won't flag an error.

Finally, the only point of this is to save space, but our code was taken from a machine with 8k roms and put on one with 16k roms, there is no need to save a few bytes per program this way.

Also, this is premature optimization.  You shouldn't put in optimizations that can break before code is finalized. 

****************************************************************
I don't have the ability to test all the code I changed, so I'm asking that this request be tested by someone capable of doing the testing.   I can verify that it fixed two bugs that I'm aware of.

Thank you.