### PR TITLE
$8F (set PETSCII-UC even if ISO) printed first after reset

### DIFF
--- a/basic/init.s
+++ b/basic/init.s
@@ -128,7 +128,7 @@ initv1	lda bvtrs,x
 chke0	.byt $00
 
 fremes
-	.byt $93
+	.byt $8f, $93
 	.byt $9c, $df, $12, $20, $20, $df, $92, $20, $20, $20, $12, $a9, $20, $20, $92, $a9, 13
 	.byt $9a, $20, $df, $12, $20, $20, $df, $92, $20, $12, $a9, $20, $20, $92, $a9
 	.byt 5, "  **** COMMANDER X16 BASIC V2 ****", 13


### PR DESCRIPTION
This fixes issue https://github.com/commanderx16/x16-rom/issues/82.

I've tested a little. This makes the ROM longer by one byte, I presume, and that might have some side effects that I don't know about.