### PR TITLE
Swap foreground/background PETSCII control code.

### DIFF
--- a/kernal/editor.1.s
+++ b/kernal/editor.1.s
@@ -845,6 +845,18 @@ dnline	ldx tblx
 dwnbye	rts
 
 chkcol
+        cmp #$02    ; check ctrl-b for invert.
+        bne ntinv
+        lda color    ; get current text color.
+        asl a        ; swap msn/lsn.
+        adc #$80
+        rol a
+        asl a
+        adc #$80
+        rol a
+        sta color    ; stash back.
+        rts
+ntinv
 	ldx #15         ;there's 15 colors
 chk1a	cmp coltab,x
 	beq chk1b


### PR DESCRIPTION
Swaps the foreground and background colors using ctrl-b ($02). Used for setting text bg color by setting fg color, swapping, and setting new fg color. Also can be used as a single code reverse toggle.

![Untitled-1](https://user-images.githubusercontent.com/14863532/69192914-97e63a80-0af3-11ea-88ba-b1a9076b60f7.png)
