### PR TITLE
Added hexadecimal qualifier to immediate value in cbdos/sdcard.asm

### DIFF
--- a/cbdos/sdcard.asm
+++ b/cbdos/sdcard.asm
@@ -250,7 +250,7 @@ sd_cmd_response_wait:
 @l:			dey
 			beq sd_block_cmd_timeout ; y already 0? then invalid response or timeout
 			jsr spi_r_byte
-			bitimm 80	; bit 7 clear
+			bitimm $80	; bit 7 clear
 			bne @l  ; no, next byte
 			cmp #$00 ; got cmd response, check if $00 to set z flag accordingly
 			rts


### PR DESCRIPTION
In the current commit, the line 253 is assembled to "d3f1 89 50    bit #$50". According to the comment in the source file, this is not what was intended.

Superficial testing shows no functional difference whether this patch is applied or not.