### PR TITLE
Fix for mangled accumulator after color swap.

### DIFF
--- a/kernal/editor.s
+++ b/kernal/editor.s
@@ -802,6 +802,7 @@ chkcol
         adc #$80
         rol a
         sta color    ; stash back.
+	lda #$01     ; restore .a
         rts
 ntinv
 	ldx #15         ;there's 15 colors


### PR DESCRIPTION
Possible reason for unwanted ISO swapping. May want an escape mechanism when returning from chkcol if color code / swap is handled so further control codes are not checked.