### PR TITLE
Fix CBDOS read_block to handle last block filling buffer completely

### DIFF
--- a/cbdos/main.s
+++ b/cbdos/main.s
@@ -791,6 +791,12 @@ read_block:
 	sta cur_buffer_len
 	lda #>$0200
 	sta cur_buffer_len + 1
+; need to check if we're actually down to 0 bytes
+	lda bytes_remaining_for_channel + 0,x
+	ora bytes_remaining_for_channel + 1,x
+	ora bytes_remaining_for_channel + 2,x
+	ora bytes_remaining_for_channel + 3,x
+	beq @read_block2
 	lda #0
 	sta is_last_block_for_channel,x
 	clc
@@ -804,6 +810,7 @@ read_block:
 	sta cur_buffer_len
 	lda bytes_remaining_for_channel + 1,x
 	sta cur_buffer_len + 1
+@read_block2:
 	lda #$ff
 	sta is_last_block_for_channel,x
 	clc


### PR DESCRIPTION
Reading files from the SD card was failing if the file length was an exact multiple of the block size of 512 bytes. It turns out CBDOS read_block was doing a less than comparison instead of a less than or equals, so if the last block completely filled the buffer, it would not flag it internally as being the last block, so it would continue trying to read new blocks from the file without sending an EOF. Added a check to set the last block flag when the remaining bytes hits zero.