### PR TITLE
Move fd_area after buffers to fix buffer alignment bugs

### DIFF
--- a/cbdos/fat32.inc
+++ b/cbdos/fat32.inc
@@ -22,7 +22,7 @@
 ; SOFTWARE.
 
 .ifndef IMPORTED_FROM_MAIN
-.import fd_area, sd_blktarget
+.import fd_area, fd_area_end
 .endif
 
 ; TODO FIXME replace with errno.inc from cc65 api
@@ -194,7 +194,7 @@ DIR_Entry_Deleted            = $e5
 .endstruct
 
 FD_Entry_Size         = .sizeof(F32_fd)
-FD_Entries_Max        = <((sd_blktarget - fd_area) / FD_Entry_Size)
+FD_Entries_Max        = <((fd_area_end - fd_area) / FD_Entry_Size)
 FD_INDEX_CURRENT_DIR  = 0*FD_Entry_Size    ; current dir always go to fd #0
 FD_INDEX_TEMP_DIR     = 1*FD_Entry_Size   ; temp dir always go to fd #1
 

--- a/cbdos/fat32.s
+++ b/cbdos/fat32.s
@@ -75,7 +75,7 @@ FAT_NOWRITE=1
 ;.endif
 
 .import krn_tmp, krn_tmp2, krn_tmp3, lba_addr, blocks
-.import block_data, block_fat
+.import sd_blktarget, block_data, block_fat
 
 .code
 

--- a/cbdos/main.s
+++ b/cbdos/main.s
@@ -17,7 +17,7 @@
 .import fat_name_string
 
 .export tmp1, krn_tmp, krn_tmp2, krn_tmp3, sd_tmp, lba_addr, blocks
-.export fd_area, sd_blktarget, block_data, block_fat
+.export fd_area, fd_area_end, sd_blktarget, block_data, block_fat
 
 .importzp filenameptr, krn_ptr1, krn_ptr3, dirptr, read_blkptr, buffer, bank_save
 
@@ -73,13 +73,14 @@ statusbuffer:
 	.res 512, 0
 
 ; SD/FAT32 buffers/variables
-fd_area: ; File descriptor area
-	.res 128, 0
 sd_blktarget:
 block_data:
 	.res 512, 0
 block_fat:
 	.res 512, 0
+fd_area: ; File descriptor area
+	.res 128, 0
+fd_area_end:
 tmp1:
 	.byte 0
 krn_tmp:


### PR DESCRIPTION
Because fd_area was located before sd_blktarget/block_data, it shifted the base address of that buffer to $BC80. This was breaking fat_find_next and other directory iterations because they assume the buffer is aligned on a 256-byte boundary and only check the high byte when checking to see if they've reached the end of a directory block. This caused the last 4 of every group of 16 files on the SD card to be invisible. The proper fix would be to check both high and low bytes of the address, but if the buffer is properly aligned, it's faster to be able to just check the high byte. Moving fd_area after all the disk buffers fixes this issue. In future, we need to be careful not to insert anything before/in between the 512-byte buffers in cbdos/main.s that would change this alignment.

Proper fix in fat_find_next (similar fixes needed in other functions that use sd_blktarget or block_data):
```
@l6:
      lda dirptr+1
      cmp #>(sd_blktarget + sd_blocksize)       ; end of block reached?
      bcc ff_l4                 ; no, process entry
+      lda dirptr
+      cmp #<(sd_blktarget + sd_blocksize)
+      bcc ff_l4
```