### PR TITLE
[DOS] Fix loading to the passed-in address when SA is 0

### DIFF
--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -56,8 +56,7 @@ ld20	cmp #4
 	lda #fndefault_end-fndefault
 	jsr setnam
 ;
-ld25	ldx sa          ;save sa in stack
-	phx
+ld25	ldx sa          ;save sa in .x
 	jsr luking      ;tell user looking
 	lda #$60        ;special load command
 	sta sa
@@ -78,7 +77,7 @@ ld25	ldx sa          ;save sa in stack
 	jsr acptr
 	sta eah
 ;
-	plx             ;find out old sa
+	txa             ;find out old sa
 	bne ld30        ;sa<>0 use disk address
 	lda memuss      ;else load where user wants
 	sta eal

--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -57,6 +57,7 @@ ld20	cmp #4
 	jsr setnam
 ;
 ld25	ldx sa          ;save sa in .x
+	phx
 	jsr luking      ;tell user looking
 	lda #$60        ;special load command
 	sta sa
@@ -77,7 +78,7 @@ ld25	ldx sa          ;save sa in .x
 	jsr acptr
 	sta eah
 ;
-	txa             ;find out old sa
+	plx             ;find out old sa
 	bne ld30        ;sa<>0 use disk address
 	lda memuss      ;else load where user wants
 	sta eal

--- a/kernal/cbm/channel/load.s
+++ b/kernal/cbm/channel/load.s
@@ -56,7 +56,7 @@ ld20	cmp #4
 	lda #fndefault_end-fndefault
 	jsr setnam
 ;
-ld25	ldx sa          ;save sa in .x
+ld25	ldx sa          ;save sa in stack
 	phx
 	jsr luking      ;tell user looking
 	lda #$60        ;special load command

--- a/kernal/ieee_switch.s
+++ b/kernal/ieee_switch.s
@@ -113,6 +113,7 @@ unlsn:
 
 listn:
 	pha
+	phx
 	jsr jsrfar
 	.word $c000 + 3 * 6
 	.byte BANK_CBDOS
@@ -121,17 +122,20 @@ listn:
 	lda cbdos_flags
 	ora #$80
 	sta cbdos_flags
+	plx
 	pla
 	rts
 
 @1:	lda cbdos_flags
 	and #$ff-$80
 	sta cbdos_flags
+	plx
 	pla
 	jmp serial_listn
 
 talk:
 	pha
+	phx
 	jsr jsrfar
 	.word $c000 + 3 * 7
 	.byte BANK_CBDOS
@@ -140,12 +144,14 @@ talk:
 	lda cbdos_flags
 	ora #$40
 	sta cbdos_flags
+	plx
 	pla
 	rts
 
 @1:	lda cbdos_flags
 	and #$ff-$40
 	sta cbdos_flags
+	plx
 	pla
 	jmp serial_talk
 


### PR DESCRIPTION
The code was saving the old SA in X, which was getting clobbered before it tried to use it to determine whether to save using the disk address or passed-in address. This changes "talk" and "listn" to preserve X on the stack so they are not lost at the upper levels.