### PR TITLE
Bug Fix: The wrong register was loaded into STAL+1

### DIFF
--- a/kernal/open-roms/iostack/f4a5.load.s
+++ b/kernal/open-roms/iostack/f4a5.load.s
@@ -30,7 +30,7 @@ LOAD:
 	lda MEMUSS+0
 	sta STAL+0
 	lda MEMUSS+1
-	sty STAL+1
+	sta STAL+1
 
 	; Reset status
 	jsr kernalstatus_reset


### PR DESCRIPTION
This pull request is to correct the issue discussed in [f4a5.load.s - STY vs STA](https://github.com/commanderx16/x16-rom/issues/171#issue-696453552).