### PR TITLE
fix crash in FB_set_pixels for count>255. Fixes #179

### DIFF
--- a/kernal/drivers/x16/framebuffer.s
+++ b/kernal/drivers/x16/framebuffer.s
@@ -176,7 +176,12 @@ FB_get_pixel:
 FB_set_pixels:
 	PushB r0H
 	PushB r1H
+	jsr set_pixels_FG
+	PopB r1H
+	PopB r0H
+	rts
 
+set_pixels_FG:
 	lda r1H
 	beq @a
 
@@ -193,8 +198,6 @@ FB_set_pixels:
 	iny
 	dex
 	bne :-
-	PopB r1H
-	PopB r0H
 	rts
 
 ;---------------------------------------------------------------


### PR DESCRIPTION
FB_set_pixels treated the restore of the registers wrong so it crashed when count is > 255. This has been corrected. Fixes #179 
Notice that FB_get_pixels already worked correctly.