### PR TITLE
Custom key listener

### DIFF
--- a/cfg/kernal-x16.cfgtpl
+++ b/cfg/kernal-x16.cfgtpl
@@ -16,6 +16,8 @@ SEGMENTS {
 	VARFONTS:   load = KVAR,     type = bss;
 	KVAR2:      load = KVAR2,    type = bss;
 
+	KEYEVT:		load = KEYEVT,	 type = bss;
+
 	GDRVVEC:    load = GDRVVEC,  type = bss;
 	KVECTORS:   load = KVECTORS, type = bss;
 	KVARSB0:    load = KVARSB0,  type = bss, define=yes;

--- a/cfg/x16.cfginc
+++ b/cfg/x16.cfginc
@@ -21,6 +21,7 @@ ZPBASIC:  start = $00D4, size = $002B; # BASIC (last byte used: $FE)
 
 /* $0200-$02FF: always-available variables and RAM code */
 KVAR:     start = $0200, size = $00BB; # KERNAL
+KEYEVT:   start = $02BB, size = $0002; # KERNAL KEY EVENT HANDLER JUMP VECTOR
 /*        start = $02BB, size = $0009; # reserved for KERNAL growth */
 KERNRAM:  start = $02C4, size = $0020; # KERNAL RAM code
 GDRVVEC:  start = $02E4, size = $001C; # framebuffer driver vectors

--- a/kernal/cbm/memory.s
+++ b/kernal/cbm/memory.s
@@ -8,15 +8,19 @@
 
 .include "io.inc"
 
-.import nsave, nload, nclall, ngetin, nstop, nbsout, nbasin, nclrch, nckout, nchkin, nclose, nopen, nnmi, timb, key, cinv
+.import nsave, nload, nclall, ngetin, nstop, nbsout, nbasin, nclrch, nckout, nchkin, nclose, nopen, nnmi, timb, key, cinv, receive_scancode_resume
 .importzp tmp2
-.export iobase, membot, memtop, restor, vector
+.export iobase, membot, memtop, restor, vector, keyevtvector
 
 .segment "KVAR"
 
 memstr	.res 2           ; start of memory
 memsiz	.res 2           ; top of memory
 rambks	.res 1           ; X16: number of ram banks (0 means 256)
+
+.segment "KEYEVT"
+
+keyevtvector .res 2
 
 .segment "MEMORY"
 
@@ -38,6 +42,12 @@ movos2	sta (tmp2),y    ;put in user
 	sta cinv,y      ;put in storage
 	dey
 	bpl movos1
+
+	lda #<receive_scancode_resume
+	sta keyevtvector
+	lda #>receive_scancode_resume
+	sta keyevtvector+1
+
 	rts
 ;
 vectss	.word key,timb,nnmi

--- a/kernal/drivers/x16/ps2kbd.s
+++ b/kernal/drivers/x16/ps2kbd.s
@@ -16,8 +16,9 @@
 
 .import kbdbuf_put
 .import shflag
+.import keyevtvector
 
-.export kbd_config, kbd_scan
+.export kbd_config, kbd_scan, receive_scancode_resume
 
 MODIFIER_SHIFT = 1 ; C64:  Shift
 MODIFIER_ALT   = 2 ; C64:  Commodore
@@ -244,6 +245,9 @@ rcvsc5:	pha
 	sta prefix
 	sta brkflg
 	pla ; lower byte into A
+
+	jmp (keyevtvector)	;Jump to key event handler
+receive_scancode_resume:
 	rts
 
 ;****************************************


### PR DESCRIPTION
This is a pull request illustrating a solution to an issue I opened earlier.

Essentially it does the following. At the end of the function receive_scancode in kernal/drivers/x16/ps2kbd.s it makes an indirect jump to the address stored in $02BB-BC.

This makes it possible to intercept a PS/2 scan code before it's handled by the Kernal's default keyboard routines. You may use this to get finer control over modifier keys (my initial interest). But you may also use it to catch key up and release events, which might be of interest if you for instance are programming keyboard controlled games. You may pretty much change every aspect of how the Kernal reacts to the keyboard.

A small test program intercepting the Ctrl key, printing the letter D on key down and the letter U on key up. To init the keylistener, call the setup code.

```
setup:
sei
lda #<keylistener
sta$02bb
lda #>keylistener
sta $02bc
cli
rts

keylistener:
php   ;Store these values on the stack, need to be restored if not Ctrl key
pha
phx

bcs keyup   ;receive_scancode returns C=1 if keyup event

keydown:
cmp #$14   ;PS/2 scan code for left Ctrl key
bne not_ctrl
lda #$44
jsr $ffd2    ;Kernal print routine
bra ctrl_exit

keyup:
cmp #$14
bne not_ctrl
lda #$55
jsr $ffd2

ctrl_exit:
plx     ;Pull values we stored at beginning off the stack
pla
plp
lda #0    ;By setting A=0 we will consume this key event
tax         ;X=scan code prefix, maybe it mustn't be set to zero
rts         ;Return control to the Kernal

not_ctrl:
plx         ;Restoring X, A and C from stack
pla
plp
rts         ;Return control to the Kernal, handles the key normally

```
