### PR TITLE
Fix issue #200

### DIFF
--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -90,9 +90,11 @@ imparm     = $E2
 	lda ram_bank
 	pha
 	stz ram_bank
+	lda kvswitch_tmp1
 .endmacro
 
 .macro KVARS_END_TRASH_NZ
+	sta kvswitch_tmp1
 	pla
 	sta ram_bank
 	lda kvswitch_tmp1

--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -106,7 +106,7 @@ l1:	lda nes_data
 ;              on NES and SNES.
 ;---------------------------------------------------------------
 joystick_get:
-	KVARS_START_TRASH_NZ
+	KVARS_START_TRASH_X_NZ
 	tax
 	beq @1       ; -> joy1
 	dex


### PR DESCRIPTION
KVARS_START_TRASH_NZ and KVARS_END_TRASH_NZ are preserving A across the entire function call, in the one place where they're used this seems to be both unnecessary and incorrect, the A only needs to be preserved across the macro, and explicitly *should not* be preserved across the whole call. This seems to fix joystick polling, verified with the following test:

10?JOY(1):GOTO10
RUN

See also issue #200 