### PR TITLE
Fix a race condition in joystick_get

### DIFF
--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -84,6 +84,7 @@ imparm     = $E2
 	stx ram_bank
 .endmacro
 
+; Warning: KVARS_START_TRASH_NZ and KVARS_END_TRASH_NZ are not interrupt-safe
 .macro KVARS_START_TRASH_NZ
 .import kvswitch_tmp1, kvswitch_tmp2
 	sta kvswitch_tmp1

--- a/inc/banks.inc
+++ b/inc/banks.inc
@@ -84,7 +84,8 @@ imparm     = $E2
 	stx ram_bank
 .endmacro
 
-; Warning: KVARS_START_TRASH_NZ and KVARS_END_TRASH_NZ are not interrupt-safe
+; Warning: KVARS_START_TRASH_NZ and KVARS_END_TRASH_NZ can cause a race
+; condition if interrupts are enabled.
 .macro KVARS_START_TRASH_NZ
 .import kvswitch_tmp1, kvswitch_tmp2
 	sta kvswitch_tmp1

--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -106,7 +106,7 @@ l1:	lda nes_data
 ;              on NES and SNES.
 ;---------------------------------------------------------------
 joystick_get:
-	KVARS_START_TRASH_X_NZ
+	KVARS_START
 	tax
 	beq @1       ; -> joy1
 	dex
@@ -149,7 +149,7 @@ joystick_get:
 	ldy joy4+2
 
 
-@5:	KVARS_END_TRASH_NZ
+@5:	KVARS_END
 	rts
 
 ;----------------------------------------------------------------------

--- a/kernal/drivers/x16/joystick.s
+++ b/kernal/drivers/x16/joystick.s
@@ -106,7 +106,7 @@ l1:	lda nes_data
 ;              on NES and SNES.
 ;---------------------------------------------------------------
 joystick_get:
-	KVARS_START
+	KVARS_START_TRASH_X_NZ
 	tax
 	beq @1       ; -> joy1
 	dex


### PR DESCRIPTION
KVARS_START_TRASH_NZ and KVARS_END_TRASH_NZ are not interrupt-safe. If the macros are interrupted by an ISR that also uses the KVARS macros, kvswitch_tmp1 will likely be overwritten. This pull request modifies joystick_get to use KVARS_START and KVARS_END, which are interrupt-safe. This change fixes #203. This pull request also adds a warning about interrupt safety to inc/banks.inc.