### PR TITLE
Remove ROM banking limitations from JSRFAR

### DIFF
--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -34,7 +34,6 @@
 	sta $0105,x     ;save original bank into reserved byte
 	iny
 	lda (imparm),y  ;target address bank
-	and #$07
 	ply             ;restore registers
 	plx
 	jmp jsrfar3


### PR DESCRIPTION
This pull request removes a line from inc/jsrfar.inc that limits the ROM banks that can be jumped to, which fixes #205. Considering that [this video](https://www.youtube.com/watch?v=Y-c3c3ia9Bo) mentions that the other banks may be usable with a few hardware modifications, I decided to completely remove the check rather than replacing it.