### PR TITLE
add code to preserve P register upon return from JSRFAR RAM BANK

### DIFF
--- a/inc/jsrfar.inc
+++ b/inc/jsrfar.inc
@@ -58,6 +58,8 @@ jsrfar1:
 	lda $0104,x
 	sta ram_bank    ;restore RAM bank
 jsrfar2:
+	lda $0103,x     ;overwrite reserved byte...
+	sta $0104,x     ;...with copy of .p
 	plx
 	pla
 	plp


### PR DESCRIPTION
This commit fixes #209 by adding a couple instructions to avoid clobbering P when returning from JSRFAR to RAM BANK.