### PR TITLE
[BASIC] Fix DA$ and TI$ when accessed together or with BIN$()/HEX$()

### DIFF
--- a/basic/code10.s
+++ b/basic/code10.s
@@ -61,21 +61,33 @@ isvret	sta facmo
 	lda r1H
 	jsr component2ascii
 
+	; Hours is at lofbuf+2.  But strings that start at lofbuf
+	; (which is in page 0) will get treated differently by strlit/strlitl
+	; than strings that start at lofbuf+1 or lofbuf+2 (in page 1) so
+	; shift it down.
+
+	lda lofbuf+2
+	sta lofbuf
+	lda lofbuf+3
+	sta lofbuf+1
+
+	; Copy the minutes and seconds into place
 	pla
-	sta lofbuf+4 ; MM
+	sta lofbuf+2 ; MM
 	pla
-	sta lofbuf+5 ; MM
+	sta lofbuf+3 ; MM
 	pla
-	sta lofbuf+6 ; SS
+	sta lofbuf+4 ; SS
 	pla
-	sta lofbuf+7 ; SS
+	sta lofbuf+5 ; SS
 	lda #0
-	sta lofbuf+8 ; Z
+	sta lofbuf+6 ; Z
 
-	lda #<(lofbuf+2) ; skip first two characters
-	ldy #>(lofbuf+2) ; (SPACE, '1')
-	jmp strlit
+	jmp strlitl
 
+	; Read DA$: Like $TI we convert components to
+	; ASCIIZ strings, cutting a character or two off
+	; each (SPACE, and sometimes a leading 1).
 tstr10	cpx #'D'
 	bne tstr11
 	cpy #'A'+$80
@@ -87,7 +99,7 @@ tstr10	cpx #'D'
 	ora r0L
 	bne :+
 	sta lofbuf+1
-	bra strlit1
+	jmp strlitl
 :
 	; day
 	lda r1L
@@ -115,20 +127,32 @@ tstr10	cpx #'D'
 	lda #>1900
 	jsr component2ascii2
 
+	; Year is at lofbuf+1.  
+	; Now year is at lofbuf+1.  But strings that start at lofbuf
+	; (which is in page 0) will get treated differently by strlit/strlitl
+	; than strings that start at lofbuf+1 or lofbuf+2 (in page 1) so
+	; shift it down.
+
+	ldy #0
+:	lda lofbuf+1,y       ; in
+	sta lofbuf,y         ; out
+	iny                  ; count
+	cpy #4               ; 4 bytes copied yet?
+	bne :-
+
+	; Copy the months and days into place
+	pla
+	sta lofbuf+4 ; MM
 	pla
 	sta lofbuf+5 ; MM
 	pla
-	sta lofbuf+6 ; MM
+	sta lofbuf+6 ; DD
 	pla
 	sta lofbuf+7 ; DD
-	pla
-	sta lofbuf+8 ; DD
 	lda #0
-	sta lofbuf+9 ; Z
+	sta lofbuf+8 ; Z
 
-strlit1	lda #<(lofbuf+1) ; skip first character (SPACE)
-	ldy #>(lofbuf+1)
-	jmp strlit
+	jmp strlitl
 
 component2ascii:
 	clc

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -127,7 +127,6 @@ tstr10	cpx #'D'
 	lda #>1900
 	jsr component2ascii2
 
-	; Year is at lofbuf+1.  
 	; Now year is at lofbuf+1.  But strings that start at lofbuf
 	; (which is in page 0) will get treated differently by strlit/strlitl
 	; than strings that start at lofbuf+1 or lofbuf+2 (in page 1) so

--- a/basic/code14.s
+++ b/basic/code14.s
@@ -83,7 +83,7 @@ strd	jsr chknum
 	jsr foutc
 	pla
 	pla
-	lda #<lofbuf
+strlitl	lda #<lofbuf
 	ldy #>lofbuf
 	beq strlit
 strini	ldx facmo

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -128,9 +128,7 @@ bind:	jsr chrget ; get char
 	jsr chkcls ; end of conversion, check closing paren
 	pla        ; remove return address from stack
 	pla
-        lda #<(lofbuf)
-	ldy #>(lofbuf)
-	jmp strlit  ; allocate and return string value
+	jmp strlitl; allocate and return string value from lofbuf
 
 ; convert byte to hex in zero terminated string and
 ; return it to BASIC
@@ -159,9 +157,7 @@ hexd:	jsr chrget ; get char
 	jsr chkcls ; end of conversion, check closing paren
 	pla        ; remove return address from stack
 	pla
-        lda #<lofbuf
-	ldy #>lofbuf
-	jmp strlit  ; allocate and return string value
+	jmp strlitl; allocate and return string value from lofbuf
 
 ; convert byte into hex ASCII in A/Y
 ; copied from monitor.s


### PR DESCRIPTION
Curious bug in DA$/TI$ (date + time) in X16 BASIC.

"PRINT DA$;TI$" was fine but "PRINT DA$+TI$" would get corrupted DA$.  BIN$() and HEX$() would corrupt DA$/TI$ but not be corrupted in turn.

The cause of this issue was how 'strlit' handled the input string, depending on what page it started in.  Pages 0 and 2 seem to get special treatment (I think they're copied while other pages, assumed to be BASIC program code, are not).

DA$, TI$, BIN$(), and HEX$() all use 'lofbuf' ($FF).  To skip initial matter, DA$ and TI$ pass 'lofbuf+2' and 'lofbuf+1' which are in page 1.  So later uses of 'lofbuf' could corrupt the string.

Workaround is to use DA$+"" or the like to force it to copy the string.

Attachment: [da-ti-test.txt](https://github.com/commanderx16/x16-rom/files/7112172/da-ti-test.txt) a BASIC program with a few tests.  Four fail with the bug; all pass (usually) with the fix.

This also fixes #178 "TI$ seems to overwrite last used string".