### PR TITLE
[BASIC] restore C flag in finh to fix null handling in GET/READ/INPUT

### DIFF
--- a/basic/code17.s
+++ b/basic/code17.s
@@ -110,6 +110,7 @@ finh	bcc fin	; skip test for 0-9
 	cmp #'$'
 	beq finh2
 	cmp #'%'
+	sec	; restore carry flag from before the comparisons; fin uses it
 	bne fin
 finh2	jmp frmevl
 ;**************************************


### PR DESCRIPTION
The 'finh' code is clobbering the C flag, which was set by 'chrget' to indicate it didn't get a digit, and used by 'fin' in parsing numbers.  That breaks the handling of end of input in GET/READ/INPUT.

This fixes problems with GET, READ, and INPUT when handling null input as a number:

- Fixes #218 in which "GET A" with empty input gets -48.
- Fixes issue in "INPUT A,B", if "B" is empty it gets a bogus number instead.
- Fixes issue in "READ A" / "DATA ," where it gets syntax error instead of 0 and 0.

With the fix, the behavior is the same as on Commodore 64 (except for "$" and "%" prefixes).

Attached to this pull request: three programs used in testing: 
[finh-sec-test-1.bas.txt](https://github.com/commanderx16/x16-rom/files/7150064/finh-sec-test-1.bas.txt)
[finh-sec-test-2.bas.txt](https://github.com/commanderx16/x16-rom/files/7150066/finh-sec-test-2.bas.txt)
[finh-sec-test-3.bas.txt](https://github.com/commanderx16/x16-rom/files/7150067/finh-sec-test-3.bas.txt)

