### PR TITLE
[KERNAL] correctly disable graphics layer when returning to text mode

### DIFF
--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -208,7 +208,10 @@ swpp3:	ldx #40
 
 swpp2:	pha
 	bcs swppp4
-	stz VERA_L0_CONFIG	; Disable layer 0
+	; Disable layer 0
+	lda VERA_DC_VIDEO
+	and #$ef
+	sta VERA_DC_VIDEO
 
 swppp4:	pla
 	sta VERA_DC_HSCALE


### PR DESCRIPTION
Switching to graphics mode, then back to text mode, is leaving garbage on the screen.  Example:
`SCREEN128:SCREEN0
`
Seen with current ROM & emulator code; also in the web based emulator.

The problem seems to be:
`stz VERA_L0_CONFIG	; Disable layer 0
`

According to VERA Programmer's Reference Guide, zeroing L0_CONFIG won't disable layer 0.  Instead clearing the $10 bit of DC_VIDEO does it.  This corresponds to what's done in FB_init (in kernal/drivers/x16/framebuffer.s) to enable layer 0.

Of course, it's possible real VERA is different; I wouldn't know.

Fixes #165 