### PR TITLE
[BASIC] save bank setting in VPOKE and VPEEK so it won't be lost;

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -186,8 +186,7 @@ byte_to_hex_ascii:
 vpeek	jsr chrget
 	jsr chkopn ; open paren
 	jsr getbyt ; byte: bank
-	txa
-	pha
+	phx
 	jsr chkcom
 	lda poker
 	pha
@@ -208,8 +207,7 @@ vpeek	jsr chrget
 
 ;***************
 vpoke	jsr getbyt ; bank
-	txa
-	pha
+	phx
 	jsr chkcom
 	jsr getnum
 	pla

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -186,7 +186,8 @@ byte_to_hex_ascii:
 vpeek	jsr chrget
 	jsr chkopn ; open paren
 	jsr getbyt ; byte: bank
-	stx VERA_ADDR_H
+	txa
+	pha
 	jsr chkcom
 	lda poker
 	pha
@@ -199,15 +200,20 @@ vpeek	jsr chrget
 	sta poker + 1
 	pla
 	sta poker
+	pla
+	sta VERA_ADDR_H
 	jsr chkcls ; closing paren
 	ldy VERA_DATA0
 	jmp sngflt
 
 ;***************
 vpoke	jsr getbyt ; bank
-	stx VERA_ADDR_H
+	txa
+	pha
 	jsr chkcom
 	jsr getnum
+	pla
+	sta VERA_ADDR_H
 	lda poker
 	sta VERA_ADDR_L
 	lda poker+1


### PR DESCRIPTION
In VPEEK() and VPOKE, saving the bank selection on the stack, and not writing it to VERA_ADDR_H until *after* the address (and, for VPOKE, value) is computed.  Without that, VPEEK() within VPOKE or another VPEEK() between two banks won't work right.

The most likely use case (the one reported in #167) is `VPOKE B1, A1, F(VPEEK(B2, A2))` but `VPOKE B1, F(VPEEK(B2, A)), V` and `VPEEK(B1, F(VPEEK(B2, A)))` would also have issues.  (Writing `F(X)` as shorthand for "some expression involving `X`".)

This fixes #167 .

On the downside, it adds 1.9 microseconds to VPEEK() and VPOKE; but that's only 0.4%.

Attached: two test programs:
[issue-167-3.bas.txt](https://github.com/commanderx16/x16-rom/files/7270840/issue-167-3.bas.txt)
[issue-167-4.bas.txt](https://github.com/commanderx16/x16-rom/files/7270841/issue-167-4.bas.txt)
 