### PR TITLE
Fix: Changed Kernal FETVEC function to support 32 ROM banks

### DIFF
--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -211,7 +211,6 @@ fetch:	lda ram_bank    ;save current config (RAM)
 	txa
 	sta ram_bank    ;set RAM bank
 	plx             ;original ROM bank
-	and #$1f		;32 ROM banks, 0-31
 	php
 	sei
 	jsr fetch2

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -211,7 +211,7 @@ fetch:	lda ram_bank    ;save current config (RAM)
 	txa
 	sta ram_bank    ;set RAM bank
 	plx             ;original ROM bank
-	and #$07
+	and #$1f		;32 ROM banks, 0-31
 	php
 	sei
 	jsr fetch2


### PR DESCRIPTION
This pull request fixes issue #234

The FETVEC function did support only ROM banks 0-7, but is here changed to support ROM banks 0-31. According to the PRG, the X16 Edit will have 512 kB of ROM => 512 kB / 16 kB = 32 banks

