### PR TITLE
Fixes (and optimizations) for CODEX regression on PR 269.

### DIFF
--- a/codex/Makefile
+++ b/codex/Makefile
@@ -136,14 +136,14 @@ KSUP_DEFS = -D CPU_65C02=1  -g -D MACHINE_X16=1 --cpu 65SC02
 
 UT_INCS=$(TESTDIR)/assert.s
 
-all: cx-dc cx-mii cx-sym utest $(BUILD_DIR)/codex.bin
+all: $(BUILD_DIR)/codex.bin cx-dc cx-mii cx-sym utest $(BUILD_DIR)/codex.bin
 
 clean:
 	rm -f *.o *.l *.sym *.map *.bin
 	rm -f $(CX_OBJS)
 	rm -f test/*.o test/*.l
 
-$(BUILD_DIR)/codex.bin: $(CX_SRCS) $(CX_INCS) $(CX_OBJS) $(KSUP_VECS) $(CFG_DIR)/codex-x16.cfg
+$(BUILD_DIR)/codex.bin: $(CX_SRCS) $(CX_INCS) $(CX_OBJS) $(KSUP_VECS) $(CFG_DIR)/codex-x16.cfg cx
 	ld65 --config $(CFG_DIR)/codex-x16.cfg --mapfile $(BUILD_DIR)/codex.map -Ln $(BUILD_DIR)/codex.sym -o $(BUILD_DIR)/codex.bin $(CX_OBJS) $(KSUP_VECS)
 
 cx-dc: $(CX_DC_SRCS) $(CX_INCS) $(CX_DC_OBJS) $(PLUGIN_OBJS) $(CFG_SUBDIR)/cx-plugin.cfg

--- a/codex/src/cx-dc.s
+++ b/codex/src/cx-dc.s
@@ -2,7 +2,7 @@
 	;; Commander 16 CodeX Interactive Assembly Environment
 	;; Text decompiler. Designed to be called from ROM'ed CodeX
 	;; 
-	;;    Copyright 2020 Michael J. Allison
+	;;    Copyright 2020-2022 Michael J. Allison
 	;; 
 	;;    Redistribution and use in source and binary forms, with or without
 	;;    modification, are permitted provided that the following conditions are met:
@@ -340,6 +340,7 @@ file_save_text_program
 	
 	bne     @file_save_text_program_no_label
 
+	MoveW	r0,r1
 	aejsr   vec_meta_print_banked_label
 	jsr     file_save_emit_cr
 

--- a/codex/src/decoder.s
+++ b/codex/src/decoder.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Assembly decoder for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
 
@@ -607,10 +607,9 @@ decode_next_instruction
 ;; Input r1 - Address of opcode
 ;; Output A - The byte count
 ;;
-;; TODO: Preserve r1 in call, fix cx.s assy_down_first_byte_count
-;;
 decode_get_byte_count
 	phy
+	PushW	r1
 	lda     (r1)
 	pha
 	     
@@ -627,6 +626,7 @@ decode_get_byte_count
 	tax                                           ; stash momentarily
 	popBank
 	ply                                           ; discard old A
+	PopW	r1
 	ply
 	txa
 	rts
@@ -637,6 +637,7 @@ decode_get_byte_count
 @decode_get_instruction_byte_count
 	pla
 	jsr     decode_get_entry
+	PopW	r1
 	ldy     #1
 	lda     (M1),y                  ; Get byte count and mode
 	lsr
@@ -1230,7 +1231,7 @@ decoder_find_and_push_label
 	pushBankVar bank_meta_l
 	ldy     #0
 @decode_label_or_hex_copy_loop
-	lda     (r1),y
+	lda     (r0),y
 	beq     @decode_push_label_exit
 	phy
 	ldy     decoded_str_next
@@ -1323,11 +1324,6 @@ decode_push_hex
 	jsr     decode_push_char
 	rts
 	
-	;; todo: missing error coverage for this routine?
-	lda     #'?'
-	jsr     decode_push_char
-	rts
-
 ;; 
 ;; Push the entire value of r1 into the decode_buffer
 ;; 

--- a/codex/src/edit.s
+++ b/codex/src/edit.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Code block manipulation routines for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
 
@@ -128,16 +128,15 @@ edit_delete
 	bcc      :+
 	inc      r0H                           ; r0 = src = dst + size
 :  
-	;; TODO: Can the IncW be combined with the SBC math?
 	lda      meta_rgn_end
-	sec                                    
+	clc												; size needs +1, e.g. size = end - start + 1
 	sbc      r1L
 	sta      r2L
 	lda      meta_rgn_end+1
 	sbc      r1H
 	sta      r2H                           ; r2 = size
 
-	IncW     r2                            ; size needs +1, e.g. size = end - start + 1
+;	IncW     r2 - accomplished by the clc before the first sbc in the most recent block of code
 	         
 	popBank
 	kerjsr   MEMCOPY
@@ -203,7 +202,7 @@ edit_relocate_loop
 	cmp            #META_DATA_BYTE
 	bmi            @edit_relocate_no_meta
 	switchBankVar  bank_meta_l                            ; Effectively skip over the pseudo statement, just increment the instruction ptr
-	PopW           r1                                     ; This is where we'd relocate the pseudo .byte or .word statement TODO
+	PopW           r1
 	bra            edit_relocate_check2
 @edit_relocate_no_meta
 	switchBankVar  bank_meta_l

--- a/codex/src/encode.s
+++ b/codex/src/encode.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Single line assemblers for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
 
@@ -573,7 +573,6 @@ encode_byte_string
 
 	jsr      meta_save_expr
 
-	;; todo: missing reference to unamed label? Issue?
 	IncW     encode_pc
 	      
 	bra      @encode_string_byte_loop
@@ -608,7 +607,7 @@ encode_word_string
 	PopW     r1
 	lda      #','
 	jsr      util_split_string
-	PushW    r2
+	PushW    r2			; will become r1 on the next loop
 	lda      (r1)
 	beq      encode_byte_word_exit
 	jsr      encode_parse_expression
@@ -1237,16 +1236,13 @@ encode_str_abs_y     .byte ",Y", 0
 
 ;;
 ;; Parse an expression, return the current value, save expression in meta_i
-;; Todo support parsing decimal
+;; TODO: support parsing decimal
 ;; Input  r1, pointing to expression string
-;;        r2, address for expression  TODO: is it really this, or is it encode_pc... see @ .parse_expr_save_meta
+;;
 ;; Output r1, current value
 ;; Carry == 0, no error
 ;; Carry == 1, parse_error
 ;; Clobbers TMP2
-;;
-;; TODO: Replace evaluation with call to meta_i.meta_evaluate_expression
-;;
 ;;
 encode_parse_expression
 	lda   #META_FN_NONE

--- a/codex/src/fio.s
+++ b/codex/src/fio.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Code block manipulation routines for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
 
@@ -174,8 +174,10 @@ file_replace_ext
 ;; Load data into an extended RAM bank $A000
 ;; Input_string - filename	
 ;; Input r1 - ptr to new extension
+;;       C  - clear, do tag comparison, set, do NOT do tag comparison	
 ;;       
 file_load_bank_a000
+	php
 	MoveW      r1,r2      ; r2 = extension ptr
 	LoadW      r1,input_string
 	LoadW      r3,0
@@ -199,6 +201,9 @@ file_load_bank_a000
 	
 	dec        BANK_CTRL_RAM ; Load incremented the RAM bank
 	
+	plp
+	bcs	@file_load_bank_a000_final_exit
+
 	; Check the meta tags for compatibility with current implementation
 	LoadW      r0,meta_tag_version
 	LoadW      r1,$A000

--- a/codex/src/meta.s
+++ b/codex/src/meta.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Interface for metadata bank for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020-2021 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
 
@@ -116,23 +116,25 @@ meta_get_region
 ;; Input  - r1 == value being searched for
 ;; Output - Z  == 0 Not found
 ;;        - Z  == 1 Found, r1 is valid
-;;        - r1 ptr to label string
+;;        - r0 ptr to label string
 ;; Clobbers - M1, y
 ;;
 meta_find_label
 	pushBankVar bank_meta_l
-
+	PushW	r1
 	jsr     meta_find_label_entry
 	bne     :+
 	ldy     #2
 	lda     (M1),y
-	sta     r1L
+	sta     r0L
 	iny
 	lda     (M1),y
-	sta     r1H
+	sta     r0H
 
+	PopW	r1
 	jmp     meta_success
 :  
+	PopW	r1
 	jmp     meta_error
 
 ;;

--- a/codex/src/screen.s
+++ b/codex/src/screen.s
@@ -1,7 +1,7 @@
 ;;;
 ;;; Screen control for the Commander 16 Assembly Language Environment
 ;;;
-;;; Copyright 2020 Michael J. Allison
+;;; Copyright 2020-2022 Michael J. Allison
 ;;; License, 2-clause BSD, see license.txt in source package.
 ;;; 
  
@@ -976,15 +976,6 @@ screen_add_scrollback_address
 	
    ifVGE          scrollback_top_ptr,TMP2,@screen_add_roll
 	
-;	lda 				#>scrollback_top_ptr    ; compare high bytes
-;	cmp 				TMP2H
-;	bcc 				:+                      ; if NUM1H < NUM2H then NUM1 < NUM2
-;	bne 			 	@screen_add_roll        ; if NUM1H <> NUM2H then NUM1 > NUM2 (so NUM1 >= NUM2)
-;	lda 				#<scrollback_top_ptr    ; compare low bytes
-;	cmp 				TMP2L
-;	bcs 				@screen_add_roll        ; if NUM1L < NUM2L then NUM1 < NUM2
-
-;:
 	sec
 	lda            TMP2L
 	sbc            #2
@@ -1439,7 +1430,9 @@ rdhex_asl_value
 ;; Print the F1 F3, etc header, with labels
 ;;
 print_header
-	PushW   r1
+	ldx     #HDR_COL
+	ldy     #(HDR_ROW+1)
+	jsr     prtstr_at_xy            ; r1 has sub header from caller
 
 	ldx     #HDR_COL
 	ldy     #HDR_ROW
@@ -1451,9 +1444,6 @@ print_header
 	ldx     #0
 	ldy     SCR_ROW
 	iny                             ; Save a byte, vera_goto will store in SCR_COL, SCR_ROW
-
-	PopW    r1
-	jsr     prtstr_at_xy            ; r1 has sub header from caller
 
 	lda     #50
 	sta     SCR_COL
@@ -1482,4 +1472,4 @@ print_header
 	
 fn_header            .byte " F1   F2   F3   F4   F5    F6    F7   F8         RAM BANK = ", 0
 str_region_start     .byte "PRGM REGION[$", 0
-str_region_end       .byte "]", CR, 0
+str_region_end       .byte "]", CR, CR, 0

--- a/codex/test/utest.s
+++ b/codex/test/utest.s
@@ -1,7 +1,7 @@
 	;;
 	;; X16 CodeX Monitor Unit Tests
 	;; 
-	;;    Copyright 2020-2021 Michael J. Allison
+	;;    Copyright 2020-2022 Michael J. Allison
 	;; 
 	;;    Redistribution and use in source and binary forms, with or without
 	;;    modification, are permitted provided that the following conditions are met:
@@ -1082,7 +1082,7 @@ testMetaAddDelete
 	fail       str_meta_found1
 :  
 	pushBankVar  bank_meta_l
-	assertEqR1  str_meta1
+	assertEqR0  str_meta1
 	popBank
 	       
 	LoadW      r1,str_meta2
@@ -1096,7 +1096,7 @@ testMetaAddDelete
 	fail       str_meta_found2
 :  
 	pushBankVar  bank_meta_l
-	assertEqR1  str_meta2
+	assertEqR0  str_meta2
 	popBank
 
 	;; Double check for a stomp
@@ -1153,15 +1153,15 @@ testMetaAddDelete
 	pushBankVar    bank_meta_l
 	LoadW          r1,$1000
 	jsr            meta_find_label
-	assertEqR1     str_meta0
+	assertEqR0     str_meta0
 	      
 	LoadW          r1,$123A
 	jsr            meta_find_label
-	assertEqR1     str_meta15
+	assertEqR0     str_meta15
 	      
 	LoadW          r1,$1240
 	jsr            meta_find_label
-	assertEqR1     str_meta2
+	assertEqR0     str_meta2
 	      
 	popBank
 	       


### PR DESCRIPTION
This fixes issue #276. Previous pull request fixed many issues in CODEX, but plugins were disabled. This PR fixes the regression. Also includes corrections for many TODOs embedded in CODEX, resulting in some byte savings. (needed for future work).