### PR TITLE
Clear Z flag before leaving sda_low

### DIFF
--- a/kernal/drivers/x16/i2c.s
+++ b/kernal/drivers/x16/i2c.s
@@ -189,6 +189,7 @@ rec_bit:
 sda_low:
 	lda #SDA
 	tsb ddr
+	ina             ; clear Z
 	rts
 
 i2c_stop:


### PR DESCRIPTION
This PR fixes #323 by ensuring Z flag is clear when returning from `sda_low`.

Tested on hardware where RTC could not have its time set on r41; RTC time changes (e.g. `TI$="235959"` from BASIC) correctly take effect after this change.