### PR TITLE
Enable RTC backup battery

### DIFF
--- a/kernal/drivers/x16/rtc.s
+++ b/kernal/drivers/x16/rtc.s
@@ -107,7 +107,11 @@ rtc_set_date_time:
 	lda r1L
 	jsr i2c_write_byte_as_bcd ; 4: day
 
-	ldy #2
+	dey
+	lda #$08
+	jsr i2c_write_byte_as_bcd ; 3: day of week
+
+	dey
 	lda r1H
 	jsr i2c_write_byte_as_bcd ; 2: hour (bit 6: 0 -> 24h mode)
 


### PR DESCRIPTION
This change sets the VBATEN bit in the weekday register on the RTC. Preservation of other bits is not done, therefore as a side effect this will set the weekday to 0 (no weekday set) and clear the power fail status bit.