### PR TITLE
Fixing GEOS issues

### DIFF
--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -65,6 +65,7 @@ codex:
 
 ;***************
 geos:
+	sec
 	jsr bjsrfar
 	.word $c000 ; entry
 	.byte BANK_GEOS

--- a/basic/x16additions.s
+++ b/basic/x16additions.s
@@ -65,7 +65,7 @@ codex:
 
 ;***************
 geos:
-	sec
+	sei
 	jsr bjsrfar
 	.word $c000 ; entry
 	.byte BANK_GEOS

--- a/geos/kernal/mouse/mouse2.s
+++ b/geos/kernal/mouse/mouse2.s
@@ -234,8 +234,12 @@ DoMouseFault:
 
 .export MouseInit
 MouseInit:
-	lda #1 ; default pointer
-	ldx #2 ; scale
+	sec			; Get screen dimensions
+	jsr gjsrfar
+	.word screen_mode
+	.byte BANK_KERNAL
+
+	lda #1 			; Use default pointer
 	jsr gjsrfar
 	.word mouse_config
 	.byte BANK_KERNAL


### PR DESCRIPTION
I have a partial fix of GEOS issues:

- After launching GEOS, the mouse don't work. Sometimes it will not be moving at all. Sometimes it moves within a very confined space at screen top left corner. It seems this is simply due to mouse screen resolution params not set correctly on GEOS init.

- I'm not sure my other commit is necessary, but I think it might be. GEOS is launched by the BASIC statement GEOS, that is code running in ROM bank 4. That code will switch to GEOS ROM bank 3 and call the entry point at $c000. As far as I can tell, GEOS has its own IRQ handler which is called by the IRQ vector ($fffe-ffff, IIRC). I guess bad things could happen if the IRQ handler is called before GEOS is setup. Currently there's a small window for that to happen, between the entry point at $c000 and the SEI at the beginning of __ResetHandle. I think it will take five processor cycles from the entry point until interrupts are disabled at _ResetHandle. One VBLANK is 133,333 cycles if the 65C02 is running at 8 MHz. So there's like one in 26,667 this will actually occur or once every 444 seconds (VBLANK 60 Hz). To prevent this, IRQ could be disabled before switching to the GEOS bank.

This fix makes it possible to launch GEOS without DeskTop image attached; and the mouse moves correctly. Still it doesn't seem to react to button clicks.

Also, if you attach APPS64.D64 to the emulator, the mouse is not working at all again. But do I have the correct GEOS DeskTop image? Hard to know.