### PR TITLE
Add WAI to text input busy loop

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -249,8 +249,10 @@ loop3
 .ifp02
 	beq loop3
 .else
+        ; power saving: a character from the keyboard
+	; cannot arrive before the next timer IRQ
 	bne ploop3
-.byte	$CB	; WAI instruction
+        .byte $cb       ; WAI instruction
 	bra loop3
 ploop3
 .endif

--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -246,7 +246,14 @@ loop3
 	jsr kbdbuf_get
 	sta blnsw
 	sta autodn      ;turn on auto scroll down
+.ifp02
 	beq loop3
+.else
+	bne ploop3
+.byte	$CB	; WAI instruction
+	bra loop3
+ploop3
+.endif
 	pha
 	php
 	sei


### PR DESCRIPTION
I was messing around with box16's added tools, and while looking at the CPU Visualizer, I realized that when you idle at the BASIC prompt, the system spends a lot of time in a busy loop. The emulator can handle the `WAI` instruction (commanderx16/x16-emulator#287), so I figured I'd try to update the ROM to use it. I'm not very familiar with the ROM project, so there might have been a better way to implement this, but I did test it and it did work for me. cc65 lacks a `WAI` mnemonic for the 65C02 (even though it has it for the 65816), so I had to use a `.byte` directive to add it.