### PR TITLE
[KERNAL] Initialize graphics driver on startup (#342)

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -173,7 +173,12 @@ cint	jsr iokeys
 	jsr panic       ;set up vic
 
 	; XXX this is too specific
-	lda #0          ;80x60
+	; Screen mode: First 320x240 graphics mode (just to initialize
+	; the framebuffer driver) then 80x60 text mode.
+	lda #128        ;320x240 graphics
+	clc
+	jsr screen_mode
+	lda #0          ;80x60 text
 	clc
 	jsr screen_mode ;set screen mode to default
 ;


### PR DESCRIPTION
Does it by going to graphics mode before text mode.

That's kind of a dumb way to fix it, but it works in my testing. It has the potential to cause a brief video "glitch" on startup or reset. On startup I haven't noticed one (beyond what's already there). On reset it briefly goes to 40x30 text mode before going back to 80x60.

This assumes "silent failure" when issuing graphics commands in text mode is the right way to address issue #342. That's what currently happens after "SCREEN128:SCREEN0".

Test BASIC program attached, because I like to write these. 😀
[text-and-gfx.txt](https://github.com/commanderx16/x16-rom/files/9845678/text-and-gfx.txt)
