### PR TITLE
[BASIC] fail graphics commands in non graphics mode (#342)

### DIFF
--- a/basic/graph.s
+++ b/basic/graph.s
@@ -96,7 +96,14 @@ char	jsr get_point
 
 linfc	jmp fcerr
 
+ngmerr	ldx #errngm                 ; error code for not graphics mode
+	jmp error
+
 get_point:
+	sec
+	jsr screen_mode             ; what screen mode are we in?
+	asl a                       ; is it graphics mode?
+	bcc ngmerr                  ; if not: that's an error
 	jsr frmadr
 	lda poker
 	sta x1L

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -185,7 +185,7 @@ reddy	.byt $d,"READY.",$d,0
 erbrk	=30
 brktxt	.byt $d
 err30	.byt "BREAK",0,$a0 ;shifted space
-err31	.byt "NOT GRAPHICS MOD",$c5
+err31	.byt "NOT GRAPHICS MOD", 'E'+$80
 errngm	=31
 
 forsiz	=$12

--- a/basic/token2.s
+++ b/basic/token2.s
@@ -176,6 +176,7 @@ errtab	.word err01
 	.word err28
 	.word err29
 	.word err30
+	.word err31
 
 okmsg	.byt $d,"OK",$d,$0
 err	.byt " ERROR",0
@@ -184,6 +185,8 @@ reddy	.byt $d,"READY.",$d,0
 erbrk	=30
 brktxt	.byt $d
 err30	.byt "BREAK",0,$a0 ;shifted space
+err31	.byt "NOT GRAPHICS MOD",$c5
+errngm	=31
 
 forsiz	=$12
 fndfor	tsx


### PR DESCRIPTION
with a new error message for it, "?NOT GRAPHICS MODE". This changes the commands PSET, LINE, RECT, FRAME, and CHAR.

The old behavior was:
PSET, LINE, RECT, and FRAME would crash to monitor, if graphics mode had never been entered. (CHAR didn't.) If graphics mode had been entered and exited, they appeared to do nothing.

This fix does impose a performance penalty, calling "screen_mode" with each operation. The attached test program [gfx-speed-2.bas.txt](https://github.com/commanderx16/x16-rom/files/9885186/gfx-speed-2.bas.txt)
showed a performance penalty of 40.5 microseconds per command -- 6.2% of the time for PSET (the fastest of the commands).

Some alternative ways of finding out the screen mode didn't turn out well.
