### PR TITLE
[SCREEN] Fix #353 Color change when deleting across line boundary

### DIFF
--- a/kernal/drivers/x16/screen.s
+++ b/kernal/drivers/x16/screen.s
@@ -311,6 +311,11 @@ screen_set_position:
 ;---------------------------------------------------------------
 screen_get_color:
 	tya
+	cmp llen
+	bcc :+
+	sec
+	sbc llen
+:
 	sec
 	rol
 	bra ldapnt2
@@ -359,6 +364,11 @@ ldapnt3:
 screen_set_color:
 	pha
 	tya
+	cmp llen
+	bcc :+
+	sec
+	sbc llen
+:
 	sec
 	rol
 	bra stapnt2


### PR DESCRIPTION
The `screen_get_color` and `screen_set_color` routines didn't take into account screen modes where the text wraps at less than 80 columns.  I added a comparison and a subtraction to each routine, similar to what is already happening in the `screen_get_char` and `screen_set_char` routines.