### PR TITLE
[MATH] adjust calls and comments to functions renamed "bfaddt" etc

### DIFF
--- a/math/code18.s
+++ b/math/code18.s
@@ -63,7 +63,7 @@ fsubt	lda facsgn
 	eor argsgn	;complement arisgn.
 	sta arisgn
 	lda facexp	;set codes on facexp.
-	jmp faddt	;(y)=argexp.
+	jmp bfaddt	;(y)=argexp.
 
 fadflt
 	bcs normal	;here if signs differ. if carry, fac is set ok.

--- a/math/code19.s
+++ b/math/code19.s
@@ -126,7 +126,7 @@ div10
 fdivf
 	stx arisgn
 	jsr movfm	;put it into fac.
-	jmp fdivt	;skip over next two bytes.
+	jmp bfdivt	;skip over next instruction.
 
 
 

--- a/math/fadd.s
+++ b/math/fadd.s
@@ -42,7 +42,7 @@ faddret2 jmp movfa      ; Copy from ARG to FAC.
 fadd     jsr conupk
 
 ;--------------------------------------------------------------
-; Entry point for faddt
+; Entry point for bfaddt
 ; On entry the two values are stored in FAC and ARG.
 ; The variable arisgn contains the XOR of the two sign bits.
 ; Additionally, the Z-flag is the value of the FAC exponent.

--- a/math/fmult.s
+++ b/math/fmult.s
@@ -45,7 +45,7 @@
 fmult    jsr conupk
 
 ;--------------------------------------------------------------
-; Entry point for fmultt
+; Entry point for bfmultt
 ; On entry the two values are stored in FAC and ARG.
 ; The variable arisgn contains the XOR of the two sign bits.
 ; Additionally, the Z-flag is the value of the FAC exponent.
@@ -225,7 +225,7 @@ mul10
 
 ; 3. FAC += ARG
          stz arisgn
-         jsr faddt      ; The Z flag is clear here.
+         jsr bfaddt     ; The Z flag is clear here.
 
 ; 4. FAC *= 2
          inc facexp

--- a/math/fsqr.s
+++ b/math/fsqr.s
@@ -142,7 +142,7 @@ sqr
 
          stz arisgn
          lda facexp
-         jsr fdivt      ; Calculate S/x
+         jsr bfdivt     ; Calculate S/x
 
          ; Copy current result (x) from TEMP2 to ARG
          lda tempf2
@@ -157,7 +157,7 @@ sqr
          stx arglo
 
          lda facexp
-         jsr faddt      ; Calculate x + S/x
+         jsr bfaddt     ; Calculate x + S/x
          dec facexp     ; Divide result by 2
 
          dec itercnt

--- a/math/jumptab.s
+++ b/math/jumptab.s
@@ -85,21 +85,21 @@
 	jmp fadd   ; $B867
 
 	; FAC += ARG
-	; [FIXED VERSION of "faddt2"]
+	; [FIXED VERSION of "bfaddt"]
 	jmp faddt
 
 	; FAC *= mem(.Y:.A)
 	jmp fmult  ; $BA28
 
 	; FAC *= ARG
-	; [FIXED VERSION of "fmultt2"]
+	; [FIXED VERSION of "bfmultt"]
 	jmp fmultt
 
 	; FAC = mem(.Y:.A) / FAC
 	jmp fdiv   ; $BB0F
 
 	; FAC /= ARG
-	; [FIXED VERSION of "fdivt2"]
+	; [FIXED VERSION of "bfdivt"]
 	jmp fdivt
 
 	; FAC = log(FAC)
@@ -118,7 +118,7 @@
 	jmp fpwr
 
 	; FAC = ARG^FAC
-	; [FIXED VERSION of "fpwrt2"]
+	; [FIXED VERSION of "bfpwrt"]
 	jmp fpwrt
 
 	; FAC = e^FAC


### PR DESCRIPTION
fixes issue #352 in which some uses of SQR() in BASIC hung or overflowed

Passes the "fp/" tests -- giving the same result as before. On the two one-liners given in #352, it doesn't overflow/hang but gives the same results as Commodore 64.
