### PR TITLE
modify CLRCHN to return prev. input file in .A and previous output file in .X

### DIFF
--- a/kernal/open-roms/iostack/f333.clrchn.s
+++ b/kernal/open-roms/iostack/f333.clrchn.s
@@ -19,13 +19,16 @@ CLRCHN:
 	; FALLTROUGH
 
 clrchn_reset: ; entry needed by setup_vicii
-
-	; Set input device number to keyboard
-	lda #$00
-	sta DFLTN
-
+	
+	; Load previous output device num to .X
+	ldx DFLTO
 	; Set output device number to screen
 	lda #$03
 	sta DFLTO
+
+	; Load previous input device number to .A
+	lda DFLTN
+	; Set input device number to keyboard
+	stz DFLTN
 
 	rts


### PR DESCRIPTION
- CLRCHN previously clobbered .A and .X so this change does not change compatibility.
- Currently there is no way to view the input / output file no's without peeking at kernal variables