### PR TITLE
Build ROM in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: ROM Build CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install Dependencnies
+        run: |
+          sudo apt-get install -y make build-essential
+          git clone https://github.com/cc65/cc65.git
+          cd cc65
+          make -j4
+          sudo make install
+      - name: Build ROM
+        run: make
+      - name: Archive firmwares results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ROM Image
+          path: build/x16/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-      - name: Install Dependencnies
+      - name: Install Dependencies
         run: |
           sudo apt-get install -y make build-essential
           git clone https://github.com/cc65/cc65.git
@@ -19,9 +19,14 @@ jobs:
           make -j4
           sudo make install
       - name: Build ROM
-        run: make
-      - name: Archive firmwares results
+        run: |
+          make
+          mkdir artifact
+          cp build/x16/*.h artifact/.
+          cp build/x16/*.sym artifact/.
+          cp build/x16/rom.bin artifact/.
+      - name: Archive Build Result
         uses: actions/upload-artifact@v3
         with:
           name: ROM Image
-          path: build/x16/
+          path: artifact


### PR DESCRIPTION
Get Github Actions to spin up a Ubuntu machine, clone, compile and install the latest cc65 toolchain from the git on it, make the ROM image, upload as an artefact. Very simplistic. See [here](https://github.com/maxgerhardt/x16-rom/actions).

The build time of ~1.5 minutes can be shortened if cc65 is installed from the package repos instead of bleeding edge, but I wanted to be sure the latest is used.

Correctly boots to the BASIC prompt when paired with the lates x16-emulator build.