### PR TITLE
implement FB_set_palette

### DIFF
--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -73,22 +73,32 @@ FB_get_info:
 ;
 ; Function:  Set (a part of) the VERA's color palette
 ; Pass  :    r0       pointer to color palette data
-;            a        start byte index
-;            x        byte count
+;            a        VERA palette start color index
+;            x        number of colors to set (0=256)
 ;---------------------------------------------------------------
 FB_set_palette:
-	tay
 	stz  VERA_CTRL
-	lda  #%00010001
-	sta  VERA_ADDR_H
-	lda  #$fa
-	sta  VERA_ADDR_M
-	stz  VERA_ADDR_L
-@1:	lda  (r0),y
-	sta  VERA_DATA0
+	ldy  #%00010001
+	sty  VERA_ADDR_H
+	ldy  #$fa
+	asl  a
+	bcc  @1
 	iny
-	dex
-	bne  @1
+@1:	sty  VERA_ADDR_M
+	sta  VERA_ADDR_L
+	ldy  #0
+@loop:	lda  (r0),y
+	sta  VERA_DATA0
+	inc  r0
+	bne  @3
+	inc  r0+1
+@3:	lda  (r0),y
+	sta  VERA_DATA0
+	inc  r0
+	bne  @4
+	inc  r0+1
+@4:	dex
+	bne  @loop
 	rts
 
 ;---------------------------------------------------------------

--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -86,13 +86,12 @@ FB_set_palette:
 	iny
 @1:	sty  VERA_ADDR_M
 	sta  VERA_ADDR_L
-	ldy  #0
-@loop:	lda  (r0),y
+@loop:	lda  (r0)
 	sta  VERA_DATA0
 	inc  r0
 	bne  @3
 	inc  r0+1
-@3:	lda  (r0),y
+@3:	lda  (r0)
 	sta  VERA_DATA0
 	inc  r0
 	bne  @4

--- a/graphics/drivers/framebuffer.s
+++ b/graphics/drivers/framebuffer.s
@@ -71,12 +71,24 @@ FB_get_info:
 ;---------------------------------------------------------------
 ; FB_set_palette
 ;
-; Return:    r0       pointer
-;            a        start index
-;            x        count
+; Function:  Set (a part of) the VERA's color palette
+; Pass  :    r0       pointer to color palette data
+;            a        start byte index
+;            x        byte count
 ;---------------------------------------------------------------
 FB_set_palette:
-	; TODO
+	tay
+	stz  VERA_CTRL
+	lda  #%00010001
+	sta  VERA_ADDR_H
+	lda  #$fa
+	sta  VERA_ADDR_M
+	stz  VERA_ADDR_L
+@1:	lda  (r0),y
+	sta  VERA_DATA0
+	iny
+	dex
+	bne  @1
 	rts
 
 ;---------------------------------------------------------------


### PR DESCRIPTION
Implements the FB_set_palette kernal routine.

A few remarks/questions:

- The index and count are interpreted to mean the *number of colors*, not a byte index. This allows access to all 256 colors and 512 byte palette locations, using only a single register for each. The documentation wasn't clear on this.

- is it okay to leave vera's autoincrement enabled at the end of the routine?