### PR TITLE
reset VERA and YM in IOINIT kernal routine to silence sound on software reset

### DIFF
--- a/kernal/drivers/x16/x16.s
+++ b/kernal/drivers/x16/x16.s
@@ -25,6 +25,8 @@
 ;            -- This is KERNAL API --
 ;---------------------------------------------------------------
 ioinit:
+	lda #%10000000
+	sta VERA_CTRL        ; reset Vera
 	jsr vera_wait_ready
 	jsr serial_init
 	jsr entropy_init


### PR DESCRIPTION
This silences PSG sounds on system reset (or actually, re-initialization / software reset) and also puts the YM-2151 back into a clear state.

Fixes #330 