### PR TITLE
Possible fix for issue 350 (dos file copy error)

### DIFF
--- a/dos/functions.s
+++ b/dos/functions.s
@@ -658,9 +658,8 @@ copy_do:
 
 	bra @cloop
 
-	BANKING_END
-
 @done:
+	BANKING_END
 	; close source
 	lda @context_src
 	jsr fat32_set_context
@@ -678,6 +677,7 @@ copy_do:
 	rts
 
 @error_errno:
+	BANKING_END
 	jsr convert_errno_status
 	pha
 	lda @context_src

--- a/dos/functions.s
+++ b/dos/functions.s
@@ -51,6 +51,7 @@
 	jsr free_context
 .endmacro
 
+.import bank_save
 ram_bank = 0
 
 .macro BANKING_START
@@ -609,7 +610,6 @@ copy_start:
 ;
 ; Append one file to destination file.
 ;---------------------------------------------------------------
-.import bank_save
 copy_do:
 @context_src = tmp0
 	jsr alloc_context

--- a/dos/functions.s
+++ b/dos/functions.s
@@ -51,6 +51,23 @@
 	jsr free_context
 .endmacro
 
+ram_bank = 0
+
+.macro BANKING_START
+	pha
+	lda ram_bank
+	sta bank_save
+	stz ram_bank
+	pla
+.endmacro
+
+.macro BANKING_END
+	pha
+	lda bank_save
+	sta ram_bank
+	pla
+.endmacro
+
 .bss
 
 cur_medium:
@@ -592,6 +609,7 @@ copy_start:
 ;
 ; Append one file to destination file.
 ;---------------------------------------------------------------
+.import bank_save
 copy_do:
 @context_src = tmp0
 	jsr alloc_context
@@ -605,6 +623,8 @@ copy_do:
 	bcc @error_errno
 
 @cloop:
+	BANKING_START
+	
 	; read
 	lda @context_src
 	jsr fat32_set_context
@@ -637,6 +657,8 @@ copy_do:
 	bcc @error_errno
 
 	bra @cloop
+
+	BANKING_END
 
 @done:
 	; close source


### PR DESCRIPTION
This is a possible fix for issue #350 

File copying seems to work again when I test manually.

It runs test/dos.bas to the end. Most tests give an OK response.

The following tests are reported as "known bad": 18, 23, and 45

And the following tests are reported as "skipped", don't know if that is OK or not: 43, 44, 46, and 48