### PR TITLE
modify behavior of CLALL / CLRCHN 

### DIFF
--- a/kernal/cbm/channel/clall.s
+++ b/kernal/cbm/channel/clall.s
@@ -35,8 +35,12 @@ jx750	cpx dfltn       ;is input channel ieee?
 ;restore default values
 ;
 ;
-clall2	stx dflto       ;output chan=3=screen
-	lda #0
-	sta dfltn       ;input chan=0=keyboard
+clall2	
+	ldx dflto
+	lda #3
+	sta dflto       ;output chan=3=screen 
+	
+	lda dfltn
+	stz dfltn       ;input chan=0=keyboard
 	rts
 


### PR DESCRIPTION
Modifies the behavior of the CBM CLRCHN routine. It now returns the prev. input device in .A and the prev. output device in .X
Both .A and .X were previously trampled by the routine so this change does not break compatibility.

The reason for this addition arose from examination of some CC65 routines that look at non-constant kernal variables.
![discord discussion](https://user-images.githubusercontent.com/72891927/202351951-1f883b3c-ae0d-4420-8d70-b3a806508b5a.PNG)

