### PR TITLE
Future additions of BASIC statements and functions without breaking tokenized representation

### DIFF
--- a/basic/code10.s
+++ b/basic/code10.s
@@ -221,8 +221,7 @@ snerr9:	jmp snerr
 	tay
 	lda ptrfunc,y
 	sta jmper+1
-	iny
-	lda ptrfunc,y
+	lda ptrfunc+1,y
 	sta jmper+2
 	jsr jmper
 	jmp chknum

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -211,18 +211,18 @@ isfun
 	bne nesct3
 
 	jsr chrget
-	sec
-	sbc #$80 + num_esc_statements
-	bcs :+
+	bne :+
 snerr9:	jmp snerr
-:	cmp #num_esc_functions
+:	dea
+	cmp #num_esc_functions
 	bcs snerr9
 
 	asl a
 	tay
-	lda stmdsp2+2*num_esc_statements,y
+	lda ptrfunc,y
 	sta jmper+1
-	lda stmdsp2+2*num_esc_statements+1,y
+	iny
+	lda ptrfunc,y
 	sta jmper+2
 	jsr jmper
 	jmp chknum

--- a/basic/code10.s
+++ b/basic/code10.s
@@ -213,7 +213,8 @@ isfun
 	jsr chrget
 	bne :+
 snerr9:	jmp snerr
-:	dea
+:	sec
+	sbc #$c0
 	cmp #num_esc_functions
 	bcs snerr9
 

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -92,8 +92,8 @@ rescon2	lda bufofs,x
 	lda count
 	cmp #num_esc_statements	; check if statement or function
 	bcc :+
-	adc #($c0 - num_esc_statements - 1) ; an extended function represented by $ce plus function index ($01-$7f)
-:	ora #128
+	adc #($c0 - num_esc_statements - 1) ; an extended function (index $C0-$FF)
+:	ora #128 ; an extended statement (index $80-BF)
 	ldy bufptr
 	inx
 	iny

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -88,13 +88,13 @@ rescon2	lda bufofs,x
 	beq reser2
 	cmp #128
 	bne nthis2
+
 	lda count
 	cmp #num_esc_statements	; check if statement or function
 	bcc :+
-	sbc #num_esc_statements-1 ; an extended function represented by $ce plus function index ($01-$7f)
-	bra :++
-:	ora #128 ; an extended statement represented by $ce plus (statement index | $80)
-:	ldy bufptr
+	adc #($c0 - num_esc_statements - 1) ; an extended function represented by $ce plus function index ($01-$7f)
+:	ora #128
+	ldy bufptr
 	inx
 	iny
 	pha

--- a/basic/code2.s
+++ b/basic/code2.s
@@ -88,8 +88,13 @@ rescon2	lda bufofs,x
 	beq reser2
 	cmp #128
 	bne nthis2
-	ora count
-	ldy bufptr
+	lda count
+	cmp #num_esc_statements	; check if statement or function
+	bcc :+
+	sbc #num_esc_statements-1 ; an extended function represented by $ce plus function index ($01-$7f)
+	bra :++
+:	ora #128 ; an extended statement represented by $ce plus (statement index | $80)
+:	ldy bufptr
 	inx
 	iny
 	pha

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -73,11 +73,12 @@ nqplop	bpl ploop
 	bne nesctk
 	iny
 	lda (lowtr),y
-	cmp #128 ; check if statement or function
-	bcs :+
-	adc #num_esc_statements ; a function
+	cmp #$c0 ; check if statement or function
+	bcc :+
+	sbc #($c0 - num_esc_statements - 1) ; a function
 	bra :++
-:	sbc #127 ; a statement
+:	sec
+	sbc #127 ; a statement
 :	tax
 	sty lstpnt
 	ldy #255

--- a/basic/code3.s
+++ b/basic/code3.s
@@ -73,9 +73,12 @@ nqplop	bpl ploop
 	bne nesctk
 	iny
 	lda (lowtr),y
-	sec
-	sbc #127
-	tax
+	cmp #128 ; check if statement or function
+	bcs :+
+	adc #num_esc_statements ; a function
+	bra :++
+:	sbc #127 ; a statement
+:	tax
 	sty lstpnt
 	ldy #255
 resrch2	dex


### PR DESCRIPTION
This code is intended to make it possible to add future BASIC statements and functions without breaking the tokenized representation of BASIC programs.

Currently there are some 25 extended BASIC statements and 7 extended BASIC functions in the master branch. The interpreter treats statements and functions differently. A function returns a value, a statement does not. The extended statements and functions are tokenized with two bytes, first $CE and then the index of the statement/function with bit 7 set. If you want to add a new BASIC statement to the end of the list of statements, that will affect and increase all function indexes by one. A BASIC program in tokenized form saved to disk in an earlier ROM version may not work properly in a newer ROM version.

To handle this the tokenization may be changed, for example as follows:

- $CE still marks the start of an extended statement or function
- If bit 7 of the next byte is set, it's an extended statement. This is no change compared to the current code
- But if bit 7 of the next byte is clear, it's an extended function. I don't think the index value 0 can be used because that indicates the end of a BASIC line. Therefore, the function index is increased by one

Examples of new tokenization:
```
- $CE $80 = MON ; unchanged, the first extended statement
- $CE $98 = BANK ; unchanged, the last extended statement
- $CE $01 = VPEEK ; changed, the first extended function 
- $CE $07 = BIN$ ; changed, the last extended function
```
This PR will of coarse in itself break backward tokenization compatibility, but hopefully this is the last time we need do that. 