### PR TITLE
Ghost cursor char left behind when moving the cursor first time after boot

### DIFF
--- a/kernal/cbm/editor.s
+++ b/kernal/cbm/editor.s
@@ -179,7 +179,7 @@ cint	jsr iokeys
 ;
 	lda #2          ;uppercase PETSCII, not locked
 	sta mode
-	sta blnon       ;we dont have a good char from the screen yet
+	stz blnon       ;we dont have a good char from the screen yet
 
 	jsr emulator_get_data
 	jsr kbd_config  ;set keyboard layout


### PR DESCRIPTION
When you move the cursor the first time after boot using any of the cursor keys, most often a ghost cursor char (inverted space) is left behind at the cursor startup position. After the initial move, the cursor behaves normally.

The problem seems to be in the editor init function (label "cint"), more precisely that the variable blnon is set to 2. Before commit 7574681 the variable was initialized to 0. If you change the code so that the variable is set to 0 on boot as it was earlier, the problem goes away as far as I can tell.

This would solve issue #372 