### PR TITLE
Enable kernal to accurately detect amount of memory installed

### DIFF
--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -93,7 +93,7 @@ ramtas:
 	sta ram_bank
 	sty $a000
 	beq :+
-	inc
+	inc		; check all banks instead of only mutiples of 8
 	bne :-
 :	stz ram_bank
 	dex

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -86,19 +86,20 @@ ramtas:
 :	sta ram_bank
 	ldy $a000
 	stx $a000
+	cpx $a000	; Ensure that value is actually written
+	bne :+		; Otherwise we have reached end of RAM
 	stz ram_bank
 	cpx $a000
 	sta ram_bank
 	sty $a000
 	beq :+
-	asl
+	inc
 	bne :-
-:	tay
-	stz ram_bank
+:	stz ram_bank
 	dex
 	stx $a000
+	 ; number of RAM banks is in accumulator
 
-	tya ; number of RAM banks
 ;
 ; set bottom and top of memory
 ;

--- a/kernal/drivers/x16/memory.s
+++ b/kernal/drivers/x16/memory.s
@@ -117,8 +117,6 @@ ramtas:
 	bne :--
 @test_done:
 	lda ram_bank	;number of RAM banks
-	stz ram_bank
-
 ;
 ; set bottom and top of memory
 ;


### PR DESCRIPTION
ROM was relying on the fact that the emulator wraps around to bank 0 when no more banks of memory are present. Real hardware does not have this functionality instead, writes to empty banks are not stored anywhere. For this reason I have added a bit of code that checks that a write to a bank can actually be read back, then it compares it with value on bank 0 to ensure continued support in the emulator as well.
I have tested the ROM in latest emulator and on unoffical hardware designed by Joe Burks (Wavicle)